### PR TITLE
1.4.1(104010) 메인 홈(+ 상세보기), 글추가, 프로필(+ 설정) 피드백 반영

### DIFF
--- a/SOOUM/SOOUM.xcodeproj/project.pbxproj
+++ b/SOOUM/SOOUM.xcodeproj/project.pbxproj
@@ -196,6 +196,8 @@
 		382D5CF72CFE9B8600BFA23E /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382D5CF52CFE9B8600BFA23E /* ProfileViewController.swift */; };
 		3830FFA62CEC6E3100ABA9FD /* Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3830FFA52CEC6E3100ABA9FD /* Kingfisher.swift */; };
 		3830FFA72CEC6E3100ABA9FD /* Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3830FFA52CEC6E3100ABA9FD /* Kingfisher.swift */; };
+		3834FADD2D11C5AC00C9108D /* SimpleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3834FADC2D11C5AC00C9108D /* SimpleCache.swift */; };
+		3834FADE2D11C5AC00C9108D /* SimpleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3834FADC2D11C5AC00C9108D /* SimpleCache.swift */; };
 		3836ACB42C8F045300A3C566 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3836ACB32C8F045300A3C566 /* Typography.swift */; };
 		3836ACB52C8F045300A3C566 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3836ACB32C8F045300A3C566 /* Typography.swift */; };
 		3836ACB72C8F04CD00A3C566 /* UILabel+Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3836ACB62C8F04CD00A3C566 /* UILabel+Observer.swift */; };
@@ -558,6 +560,7 @@
 		381DEA8A2CD4BBCB009F1FE9 /* WriteCardTextView+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WriteCardTextView+Rx.swift"; sourceTree = "<group>"; };
 		382D5CF52CFE9B8600BFA23E /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		3830FFA52CEC6E3100ABA9FD /* Kingfisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Kingfisher.swift; sourceTree = "<group>"; };
+		3834FADC2D11C5AC00C9108D /* SimpleCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCache.swift; sourceTree = "<group>"; };
 		3836ACB32C8F045300A3C566 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		3836ACB62C8F04CD00A3C566 /* UILabel+Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Observer.swift"; sourceTree = "<group>"; };
 		3836ACB92C8F050D00A3C566 /* UILabel+Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Typography.swift"; sourceTree = "<group>"; };
@@ -1173,6 +1176,7 @@
 				3836ACB22C8F043500A3C566 /* Typography */,
 				38D5CE0A2CBCE8CA0054AB9A /* SimpleDefaults.swift */,
 				38389B9E2CCCFB7D006728AF /* AuthKeyChain.swift */,
+				3834FADC2D11C5AC00C9108D /* SimpleCache.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -2196,6 +2200,7 @@
 				3803CF712D0159A500FD90DB /* SettingsResponse.swift in Sources */,
 				2A5BB7E12CDCBE7E00E1C799 /* OnboardingNicknameSettingViewReactor.swift in Sources */,
 				3803CF7E2D016DA200FD90DB /* TransferCodeResponse.swift in Sources */,
+				3834FADE2D11C5AC00C9108D /* SimpleCache.swift in Sources */,
 				38F720AA2CD4F15900DF32B5 /* DetailCard.swift in Sources */,
 				388009982CAC20EC002A9209 /* SOMTags+Rx.swift in Sources */,
 				2AFF95752CF5F08700CBFB12 /* TagPreviewCardCollectionViewCell.swift in Sources */,
@@ -2306,6 +2311,7 @@
 				2A44A4342CAC21A500DC463E /* SignUpResponse.swift in Sources */,
 				385620F62CA19EA900E0AB5A /* Alamofire_constants.swift in Sources */,
 				38B6AAD12CA4124B00CE6DB6 /* MainHomeViewController.swift in Sources */,
+				3834FADD2D11C5AC00C9108D /* SimpleCache.swift in Sources */,
 				2A5BB7BE2CDB870000E1C799 /* OnboardingGuideLabelView.swift in Sources */,
 				3836ACB42C8F045300A3C566 /* Typography.swift in Sources */,
 				2AFD05632D00A1E1007C84AD /* TagDetailCardResponse.swift in Sources */,

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMActivityIndicatorView.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMActivityIndicatorView.swift
@@ -87,11 +87,11 @@ class SOMActivityIndicatorView: UIActivityIndicatorView {
         
         if isAnimating {
             let rotate = CABasicAnimation(keyPath: "transform.rotation.z")
+            rotate.fromValue = 0
             rotate.toValue = NSNumber(value: Double.pi * -2.0)
             rotate.duration = 1
-            rotate.isCumulative = true
             rotate.repeatCount = Float.infinity
-            self.imageView.layer.anchorPoint = .init(x: 0.5, y: 0.5)
+            rotate.timingFunction = CAMediaTimingFunction(name: .linear)
             self.imageView.layer.add(rotate, forKey: "rotate")
         } else {
             self.imageView.layer.removeAnimation(forKey: "rotate")

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
@@ -325,13 +325,15 @@ class SOMCard: UIView {
     
     /// cardGradientLayer
     private func addGradient() {
-        cardGradientLayer.colors = [
-            UIColor.clear.cgColor,
-            UIColor.black.withAlphaComponent(0.6).cgColor
-        ]
-        cardGradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
-        cardGradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
-        cardGradientView.layer.insertSublayer(cardGradientLayer, at: 0)
+        UIView.performWithoutAnimation {
+            cardGradientLayer.colors = [
+                UIColor.clear.cgColor,
+                UIColor.black.withAlphaComponent(0.6).cgColor
+            ]
+            cardGradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
+            cardGradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+            cardGradientView.layer.insertSublayer(cardGradientLayer, at: 0)
+        }
     }
     
     /// 홈피드 모델 초기화

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMPresentationController/SOMPresentationController.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMPresentationController/SOMPresentationController.swift
@@ -245,12 +245,17 @@ class SOMPresentationController: UIPresentationController {
         let velocity = gesture.velocity(in: presentedView)
         let scrollDirection = velocity.y < 0 ? "top" : "bottom"
         let newHeight = self.currentHeight - translation.y
+        let minHeight = self.neverDismiss ? self.initalHeight : 0
         switch gesture.state {
         case .changed:
             if scrollDirection == "top" {
-                self.updateHeight(min(self.maxHeight, newHeight))
+                guard minHeight < newHeight else { break }
+                var updateHeight = min(self.maxHeight, newHeight)
+                self.updateHeight(updateHeight)
             } else {
-                self.updateHeight(max(self.neverDismiss ? self.initalHeight : 0, newHeight))
+                guard self.maxHeight > newHeight else { break }
+                var updateHeight = max(minHeight, newHeight)
+                self.updateHeight(updateHeight)
             }
         case .ended:
             if scrollDirection == "top" {

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMRefreshControl.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMRefreshControl.swift
@@ -40,7 +40,7 @@ class SOMRefreshControl: UIRefreshControl {
     }
     
     deinit {
-        self.removeObserver(self, forKeyPath: #keyPath(isRefreshing))
+        self.removeObserver(self, forKeyPath: #keyPath(isRefreshing), context: nil)
     }
     
     
@@ -93,11 +93,11 @@ class SOMRefreshControl: UIRefreshControl {
         
         if isRefreshing {
             let rotate = CABasicAnimation(keyPath: "transform.rotation.z")
+            rotate.fromValue = 0
             rotate.toValue = NSNumber(value: Double.pi * -2.0)
             rotate.duration = 1
-            rotate.isCumulative = true
             rotate.repeatCount = Float.infinity
-            self.imageView.layer.anchorPoint = .init(x: 0.5, y: 0.5)
+            rotate.timingFunction = CAMediaTimingFunction(name: .linear)
             self.imageView.layer.add(rotate, forKey: "rotate")
         } else {
             self.imageView.layer.removeAnimation(forKey: "rotate")

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
@@ -72,6 +72,7 @@ import RxSwift
      var cardSummary = CardSummary()
      
      var isDeleted = false
+     var isRefreshEnabled = false
      
      
      // MARK: - Life Cycles
@@ -393,6 +394,26 @@ extension DetailViewController: UICollectionViewDataSource {
 }
 
 extension DetailViewController: UICollectionViewDelegateFlowLayout {
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        
+        // currentOffset <= 0 일 때, 테이블 뷰 새로고침 가능
+        let offset = scrollView.contentOffset.y
+        self.isRefreshEnabled = offset <= 0
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        
+        let offset = scrollView.contentOffset.y
+        
+        // isRefreshEnabled == true 이고, 스크롤이 끝났을 경우에만 테이블 뷰 새로고침
+        if self.isRefreshEnabled,
+           let refreshControl = self.collectionView.refreshControl,
+           offset <= -refreshControl.bounds.height {
+            
+            refreshControl.beginRefreshingFromTop()
+        }
+    }
     
     func collectionView(
         _ collectionView: UICollectionView,

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewController.swift
@@ -442,7 +442,7 @@ extension MainHomeViewController: UITableViewDelegate {
         // isRefreshEnabled == true 이고, 스크롤이 끝났을 경우에만 테이블 뷰 새로고침
         if self.isRefreshEnabled,
            let refreshControl = self.tableView.refreshControl,
-           offset <= -(refreshControl.frame.origin.y + refreshControl.bounds.height) {
+           offset <= -refreshControl.bounds.height {
             
             refreshControl.beginRefreshingFromTop()
         }

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewController.swift
@@ -231,7 +231,7 @@ class MainHomeViewController: BaseNavigationViewController, View {
     func bind(reactor: MainHomeViewReactor) {
         
         // Action
-        self.rx.viewWillAppear
+        self.rx.viewDidLoad
             .map { _ in Reactor.Action.landing }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewController.swift
@@ -231,7 +231,10 @@ class MainHomeViewController: BaseNavigationViewController, View {
     func bind(reactor: MainHomeViewReactor) {
         
         // Action
-        self.rx.viewDidLoad
+        // 테이블 뷰가 스크롤이 되어 있을 시에 새로고침 X
+        self.rx.viewWillAppear
+            .withUnretained(self)
+            .filter { object, _ in object.tableView.contentOffset.y <= 0 }
             .map { _ in Reactor.Action.landing }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeViewReactor.swift
@@ -294,7 +294,12 @@ extension MainHomeViewReactor {
 extension MainHomeViewReactor {
     
     var catchClosure: ((Error) throws -> Observable<Mutation> ) {
-         return { _ in .just(.updateIsLoading(false)) }
+        return { _ in
+            .concat([
+                .just(.updateIsProcessing(false)),
+                .just(.updateIsLoading(false))
+            ])
+        }
     }
     
     func separate(displayed displayedCards: [Card], current cards: [Card]) -> [Card] {

--- a/SOOUM/SOOUM/Presentations/Main/MainTabBarController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/MainTabBarController.swift
@@ -36,7 +36,6 @@ class MainTabBarController: SOMTabBarController, View {
         super.viewWillAppear(animated)
         
         self.navigationController?.navigationBar.isHidden = true
-        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     }
     
     func bind(reactor: MainTabBarReactor) {

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/MyProfileViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/MyProfileViewCell.swift
@@ -88,9 +88,6 @@ class MyProfileViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.contentView.subviews.forEach { $0.snp.removeConstraints() }
-        self.setupConstraints()
-        
         self.disposeBag = DisposeBag()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/OtherProfileViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/OtherProfileViewCell.swift
@@ -22,6 +22,7 @@ class OtherProfileViewCell: UICollectionViewCell {
         
         static let followButtonTitle: String = "팔로우하기"
         static let didFollowButtonTitle: String = "팔로우 중"
+        static let blockedFollowButtonTitle: String = "차단 해제"
     }
     
     static let cellIdentifier = String(reflecting: OtherProfileViewCell.self)
@@ -180,7 +181,7 @@ class OtherProfileViewCell: UICollectionViewCell {
         }
     }
     
-    func setModel(_ profile: Profile) {
+    func setModel(_ profile: Profile, isBlocked: Bool) {
         if let profileImg = profile.profileImg {
             self.profileImageView.setImage(strUrl: profileImg.url)
         } else {
@@ -192,10 +193,17 @@ class OtherProfileViewCell: UICollectionViewCell {
         
         let isFollowing = profile.isFollowing ?? false
         
-        let image = UIImage(.icon(.outlined(.plus)))?.resized(.init(width: 16, height: 16), color: .som.white)
-        self.followButton.image = isFollowing ? nil : image
-        self.followButton.title = isFollowing ? Text.didFollowButtonTitle : Text.followButtonTitle
-        self.followButton.foregroundColor = isFollowing ? .som.gray600 : .som.white
-        self.followButton.backgroundColor = isFollowing ? .som.gray200 : .som.p300
+        if isBlocked {
+            self.followButton.image = nil
+            self.followButton.title = Text.blockedFollowButtonTitle
+            self.followButton.foregroundColor = .som.white
+            self.followButton.backgroundColor = .som.p300
+        } else {
+            let image = UIImage(.icon(.outlined(.plus)))?.resized(.init(width: 16, height: 16), color: .som.white)
+            self.followButton.image = isFollowing ? nil : image
+            self.followButton.title = isFollowing ? Text.didFollowButtonTitle : Text.followButtonTitle
+            self.followButton.foregroundColor = isFollowing ? .som.gray600 : .som.white
+            self.followButton.backgroundColor = isFollowing ? .som.gray200 : .som.p300
+        }
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/OtherProfileViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/OtherProfileViewCell.swift
@@ -91,9 +91,6 @@ class OtherProfileViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.contentView.subviews.forEach { $0.snp.removeConstraints() }
-        self.setupConstraints()
-        
         self.disposeBag = DisposeBag() 
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooter.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooter.swift
@@ -16,6 +16,10 @@ import RxSwift
 
 class ProfileViewFooter: UICollectionReusableView {
     
+    enum Text {
+        static let blockedText: String = "차단한 계정입니다"
+    }
+    
     private let flowLayout = SOMTagsLayout().then {
         $0.scrollDirection = .vertical
         $0.minimumLineSpacing = .zero
@@ -38,6 +42,13 @@ class ProfileViewFooter: UICollectionReusableView {
         
         $0.dataSource = self
         $0.delegate = self
+    }
+    
+    private let blockedLabel = UILabel().then {
+        $0.text = Text.blockedText
+        $0.textColor = .som.gray400
+        $0.typography = .som.body1WithBold
+        $0.isHidden = true
     }
     
     private(set) var writtenCards = [WrittenCard]()
@@ -64,15 +75,25 @@ class ProfileViewFooter: UICollectionReusableView {
     
     private func setupConstraints() {
         
-        self.addSubviews(self.collectionView)
+        self.addSubview(self.collectionView)
         self.collectionView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+        
+        self.addSubview(self.blockedLabel)
+        self.blockedLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
     }
     
-    func setModel(_ writtenCards: [WrittenCard]) {
+    func setModel(_ writtenCards: [WrittenCard], isBlocked: Bool) {
+        self.blockedLabel.isHidden = isBlocked == false
+        self.collectionView.isHidden = isBlocked
+        
         self.writtenCards = writtenCards
-        self.collectionView.reloadData()
+        if self.writtenCards != writtenCards {
+            self.collectionView.reloadData()
+        }
     }
 }
 

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooter.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooter.swift
@@ -59,9 +59,6 @@ class ProfileViewFooter: UICollectionReusableView {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.subviews.forEach { $0.snp.removeConstraints() }
-        self.setupConstraints()
-        
         self.disposeBag = DisposeBag()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooterCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooterCell.swift
@@ -30,13 +30,6 @@ class ProfileViewFooterCell: UICollectionViewCell {
         self.setupConstraints()
     }
     
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        
-        self.contentView.subviews.forEach { $0.snp.removeConstraints() }
-        self.setupConstraints()
-    }
-    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooterCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Cells/ProfileViewFooterCell.swift
@@ -22,6 +22,7 @@ class ProfileViewFooterCell: UICollectionViewCell {
         $0.textAlignment = .center
         $0.typography = .som.body3WithRegular
         $0.numberOfLines = 0
+        $0.lineBreakMode = .byTruncatingTail
     }
     
     override init(frame: CGRect) {
@@ -41,7 +42,7 @@ class ProfileViewFooterCell: UICollectionViewCell {
             $0.edges.equalToSuperview()
         }
         
-        self.backgroundImageView.addSubview(self.contentLabel)
+        self.contentView.addSubview(self.contentLabel)
         self.contentLabel.snp.makeConstraints {
             $0.top.leading.equalToSuperview().offset(10)
             $0.bottom.trailing.equalToSuperview().offset(-10)
@@ -52,5 +53,6 @@ class ProfileViewFooterCell: UICollectionViewCell {
         self.backgroundImageView.setImage(strUrl: writtenCard.backgroundImgURL.url)
         self.contentLabel.typography = writtenCard.font == .pretendard ? .som.body3WithRegular : .som.schoolBody1WithLight
         self.contentLabel.text = writtenCard.content
+        self.contentLabel.textAlignment = .center
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowerViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowerViewCell.swift
@@ -87,6 +87,7 @@ class MyFollowerViewCell: UITableViewCell {
             $0.centerY.equalToSuperview()
             $0.leading.greaterThanOrEqualTo(self.profileNickname.snp.trailing).offset(40)
             $0.trailing.equalToSuperview().offset(-20)
+            $0.width.equalTo(72)
             $0.height.equalTo(26)
         }
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowerViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowerViewCell.swift
@@ -61,12 +61,6 @@ class MyFollowerViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.profileImageView.snp.removeConstraints()
-        self.profileNickname.snp.removeConstraints()
-        self.followButton.snp.removeConstraints()
-        
-        self.setupConstraints()
-        
         self.disposeBag = DisposeBag()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowingViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowingViewCell.swift
@@ -44,6 +44,7 @@ class MyFollowingViewCell: UITableViewCell {
         $0.typography = .som.body3WithBold
         $0.foregroundColor = .som.white
         
+        $0.backgroundColor = .som.p300
         $0.layer.cornerRadius = 26 * 0.5
         $0.clipsToBounds = true
         $0.isHidden = true
@@ -107,6 +108,7 @@ class MyFollowingViewCell: UITableViewCell {
             $0.centerY.equalToSuperview()
             $0.leading.greaterThanOrEqualTo(self.profileNickname.snp.trailing).offset(40)
             $0.trailing.equalToSuperview().offset(-20)
+            $0.width.equalTo(72)
             $0.height.equalTo(26)
         }
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowingViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowingViewCell.swift
@@ -73,13 +73,6 @@ class MyFollowingViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.profileImageView.snp.removeConstraints()
-        self.profileNickname.snp.removeConstraints()
-        self.cancelFollowButton.snp.removeConstraints()
-        self.followButton.snp.removeConstraints()
-        
-        self.setupConstraints()
-        
         self.disposeBag = DisposeBag()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
@@ -87,6 +87,7 @@ class OtherFollowViewCell: UITableViewCell {
             $0.centerY.equalToSuperview()
             $0.leading.greaterThanOrEqualTo(self.profileNickname.snp.trailing).offset(40)
             $0.trailing.equalToSuperview().offset(-20)
+            $0.width.equalTo(72)
             $0.height.equalTo(26)
         }
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
@@ -61,12 +61,6 @@ class OtherFollowViewCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         
-        self.profileImageView.snp.removeConstraints()
-        self.profileNickname.snp.removeConstraints()
-        self.followButton.snp.removeConstraints()
-        
-        self.setupConstraints()
-        
         self.disposeBag = DisposeBag()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
@@ -184,14 +184,14 @@ extension FollowViewController {
         cell.selectionStyle = .none
         cell.setModel(model)
         
-        cell.cancelFollowButton.rx.throttleTap(.seconds(3))
+        cell.cancelFollowButton.rx.throttleTap(.seconds(1))
             .subscribe(onNext: { _ in
                 cell.updateButton(false)
                 reactor.action.onNext(.cancel(model.id))
             })
             .disposed(by: cell.disposeBag)
         
-        cell.followButton.rx.throttleTap(.seconds(3))
+        cell.followButton.rx.throttleTap(.seconds(1))
             .subscribe(onNext: { _ in
                 cell.updateButton(true)
                 reactor.action.onNext(.request(model.id))
@@ -212,7 +212,7 @@ extension FollowViewController {
         cell.selectionStyle = .none
         cell.setModel(model)
         
-        cell.followButton.rx.throttleTap(.seconds(3))
+        cell.followButton.rx.throttleTap(.seconds(1))
             .subscribe(onNext: { _ in
                 cell.updateButton(!model.isFollowing)
                 reactor.action.onNext(model.isFollowing ? .cancel(model.id) : .request(model.id))

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
@@ -43,6 +43,8 @@ class FollowViewController: BaseNavigationViewController, View {
     
     private(set) var follows = [Follow]()
     
+    private var isRefreshEnabled: Bool = true
+    
     
     // MARK: Override func
     
@@ -143,6 +145,26 @@ extension FollowViewController: UITableViewDataSource {
 }
 
 extension FollowViewController: UITableViewDelegate {
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        
+        // currentOffset <= 0 일 때, 테이블 뷰 새로고침 가능
+        let offset = scrollView.contentOffset.y
+        self.isRefreshEnabled = offset <= 0
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        
+        let offset = scrollView.contentOffset.y
+        
+        // isRefreshEnabled == true 이고, 스크롤이 끝났을 경우에만 테이블 뷰 새로고침
+        if self.isRefreshEnabled,
+           let refreshControl = self.tableView.refreshControl,
+           offset <= -refreshControl.bounds.height {
+            
+            refreshControl.beginRefreshingFromTop()
+        }
+    }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 74

--- a/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewController.swift
@@ -246,67 +246,67 @@ extension ProfileViewController: UICollectionViewDataSource {
         let entranceType = self.reactor?.entranceType ?? .my
         switch entranceType {
         case .my:
-            let cell: MyProfileViewCell = collectionView.dequeueReusableCell(
+            let myCell: MyProfileViewCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: MyProfileViewCell.cellIdentifier,
                 for: indexPath
             ) as! MyProfileViewCell
-            cell.setModel(self.profile)
+            myCell.setModel(self.profile)
             
-            cell.updateProfileButton.rx.tap
+            myCell.updateProfileButton.rx.tap
                 .subscribe(with: self) { object, _ in
                     let updateProfileViewController = UpdateProfileViewController()
                     updateProfileViewController.reactor = self.reactor?.reactorForUpdate()
                     object.navigationPush(updateProfileViewController, animated: true, bottomBarHidden: true)
                 }
-                .disposed(by: cell.disposeBag)
+                .disposed(by: myCell.disposeBag)
             
-            cell.followingButton.rx.tap
+            myCell.followingButton.rx.tap
                 .subscribe(with: self) { object, _ in
                     let followViewController = FollowViewController()
                     followViewController.reactor = self.reactor?.reactorForFollow(type: .following)
                     object.navigationPush(followViewController, animated: true, bottomBarHidden: true)
                 }
-                .disposed(by: cell.disposeBag)
+                .disposed(by: myCell.disposeBag)
             
-            cell.followerButton.rx.tap
+            myCell.followerButton.rx.tap
                 .subscribe(with: self) { object, _ in
                     let followViewController = FollowViewController()
                     followViewController.reactor = self.reactor?.reactorForFollow(type: .follower)
                     object.navigationPush(followViewController, animated: true, bottomBarHidden: true)
                 }
-                .disposed(by: cell.disposeBag)
+                .disposed(by: myCell.disposeBag)
             
-            return cell
+            return myCell
         case .other:
-            let cell: OtherProfileViewCell = collectionView.dequeueReusableCell(
+            let otherCell: OtherProfileViewCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: OtherProfileViewCell.cellIdentifier,
                 for: indexPath
             ) as! OtherProfileViewCell
-            cell.setModel(self.profile)
+            otherCell.setModel(self.profile)
             
-            cell.followButton.rx.throttleTap(.seconds(1))
+            otherCell.followButton.rx.throttleTap(.seconds(1))
                 .subscribe(with: self) { object, _ in
                     object.reactor?.action.onNext(.follow)
                 }
-                .disposed(by: cell.disposeBag)
+                .disposed(by: otherCell.disposeBag)
             
-            cell.followingButton.rx.tap
+            otherCell.followingButton.rx.tap
                 .subscribe(with: self) { object, _ in
                     let followViewController = FollowViewController()
                     followViewController.reactor = self.reactor?.reactorForFollow(type: .following)
                     object.navigationPush(followViewController, animated: true, bottomBarHidden: true)
                 }
-                .disposed(by: cell.disposeBag)
+                .disposed(by: otherCell.disposeBag)
             
-            cell.followerButton.rx.tap
+            otherCell.followerButton.rx.tap
                 .subscribe(with: self) { object, _ in
                     let followViewController = FollowViewController()
                     followViewController.reactor = self.reactor?.reactorForFollow(type: .follower)
                     object.navigationPush(followViewController, animated: true, bottomBarHidden: true)
                 }
-                .disposed(by: cell.disposeBag)
+                .disposed(by: otherCell.disposeBag)
             
-            return cell
+            return otherCell
         }
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewController.swift
@@ -89,6 +89,8 @@ class ProfileViewController: BaseNavigationViewController, View {
          68
     }
     
+    private var isRefreshEnabled: Bool = true
+    
     
     // MARK: Override func
     
@@ -342,6 +344,26 @@ extension ProfileViewController: UICollectionViewDataSource {
 }
 
 extension ProfileViewController: UICollectionViewDelegateFlowLayout {
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        
+        // currentOffset <= 0 일 때, 테이블 뷰 새로고침 가능
+        let offset = scrollView.contentOffset.y
+        self.isRefreshEnabled = offset <= 0
+    }
+    
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        
+        let offset = scrollView.contentOffset.y
+        
+        // isRefreshEnabled == true 이고, 스크롤이 끝났을 경우에만 테이블 뷰 새로고침
+        if self.isRefreshEnabled,
+           let refreshControl = self.collectionView.refreshControl,
+           offset <= -refreshControl.bounds.height {
+            
+            refreshControl.beginRefreshingFromTop()
+        }
+    }
     
     func collectionView(
         _ collectionView: UICollectionView,

--- a/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewReactor.swift
@@ -68,14 +68,16 @@ class ProfileViewReactor: Reactor {
             return .concat([
                 .just(.updateIsProcessing(true)),
                 self.profile(),
-                self.writtenCards(nil),
+                self.writtenCards(nil)
+                    .delay(.milliseconds(500), scheduler: MainScheduler.instance),
                 .just(.updateIsProcessing(false))
             ])
         case .refresh:
             return .concat([
                 .just(.updateIsLoading(true)),
                 self.profile(),
-                self.writtenCards(nil),
+                self.writtenCards(nil)
+                    .delay(.milliseconds(500), scheduler: MainScheduler.instance),
                 .just(.updateIsLoading(false))
             ])
         case let .moreFind(lastId):
@@ -148,6 +150,7 @@ extension ProfileViewReactor {
                     return .just(.profile(.init()))
                 }
             }
+            .catch(self.catchClosure)
     }
     
     private func writtenCards(_ lastId: String?) -> Observable<Mutation> {
@@ -169,6 +172,16 @@ extension ProfileViewReactor {
                     return .just(.writtenCards(.init()))
                 }
             }
+            .catch(self.catchClosure)
+    }
+    
+    var catchClosure: ((Error) throws -> Observable<Mutation> ) {
+        return { _ in
+            .concat([
+                .just(.updateIsProcessing(false)),
+                .just(.updateIsLoading(false))
+            ])
+        }
     }
 }
 

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/Cells/CommentHistoryViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/Cells/CommentHistoryViewCell.swift
@@ -26,19 +26,13 @@ class CommentHistoryViewCell: UICollectionViewCell {
             letterSpacing: -0.04
         )
         $0.numberOfLines = 0
+        $0.lineBreakMode = .byTruncatingTail
     }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         self.setupConstraints()
-    }
-    
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        
-        self.backgroundImageView.image = nil
-        self.contentLabel.text = nil
     }
     
     required init?(coder: NSCoder) {

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/CommentHistroyViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/CommentHistroyViewController.swift
@@ -113,6 +113,14 @@ extension CommentHistroyViewController: UICollectionViewDataSource {
         
         return cell
     }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let selectedId = self.commentHistroies[indexPath.row].id
+        
+        let detailViewController = DetailViewController()
+        detailViewController.reactor = self.reactor?.reactorForDetail(selectedId)
+        self.navigationPush(detailViewController, animated: true, bottomBarHidden: true)
+    }
 }
 
 extension CommentHistroyViewController: UICollectionViewDelegateFlowLayout {

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/CommentHistroyViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/CommentHistroyViewReactor.swift
@@ -57,3 +57,10 @@ class CommentHistroyViewReactor: Reactor {
         return state
     }
 }
+
+extension CommentHistroyViewReactor {
+    
+    func reactorForDetail(_ selectedId: String) -> DetailViewReactor {
+        DetailViewReactor.init(type: .detail, selectedId)
+    }
+}

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/termsOfService/TermsOfServiceViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/termsOfService/TermsOfServiceViewController.swift
@@ -78,7 +78,7 @@ class TermsOfServiceViewController: BaseNavigationViewController {
         
         self.privacyPolicyCellView.rx.didSelect
             .subscribe(with: self) { object, _ in
-                if let url = URL(string: "https://tiny-viscount-552.notion.site/73ff608593ff42e0830c6bc772e0ffc1?pvs=4") {
+                if let url = URL(string: "https://mewing-space-6d3.notion.site/44e378c9d11d45159859492434b6b128?pvs=4") {
                     if UIApplication.shared.canOpenURL(url) {
                         UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     }
@@ -88,7 +88,7 @@ class TermsOfServiceViewController: BaseNavigationViewController {
         
         self.termsOfServiceCellView.rx.didSelect
             .subscribe(with: self) { object, _ in
-                if let url = URL(string: "https://tiny-viscount-552.notion.site/78a2178a3c7f46d18bbfa45c880c11a5?pvs=4") {
+                if let url = URL(string: "https://mewing-space-6d3.notion.site/3f92380d536a4b569921d2809ed147ef?pvs=4") {
                     if UIApplication.shared.canOpenURL(url) {
                         UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     }
@@ -98,7 +98,7 @@ class TermsOfServiceViewController: BaseNavigationViewController {
         
         self.termsOfLocationInfoCellView.rx.didSelect
             .subscribe(with: self) { object, _ in
-                if let url = URL(string: "https://tiny-viscount-552.notion.site/b529a2cfe4034baa89a64c64b17216a7?pvs=4") {
+                if let url = URL(string: "https://mewing-space-6d3.notion.site/45d151f68ba74b23b24483ad8b2662b4?pvs=4") {
                     if UIApplication.shared.canOpenURL(url) {
                         UIApplication.shared.open(url, options: [:], completionHandler: nil)
                     }

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/Views/WriteCardView.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/Views/WriteCardView.swift
@@ -30,7 +30,6 @@ class WriteCardView: UIView {
     let writtenTags = SOMTags(configure: .horizontalWithRemove).then {
         $0.tag = 0
     }
-    var writtenTagsHeightConstraint: Constraint?
     
     let relatedTagsBackgroundView = UIView().then {
         $0.isHidden = true
@@ -38,6 +37,8 @@ class WriteCardView: UIView {
     let relatedTags = SOMTags(configure: .verticalWithoutRemove).then {
         $0.tag = 1
     }
+    
+    var writtenTagsHeightConstraint: Constraint?
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewController.swift
@@ -261,26 +261,23 @@ class WriteCardViewController: BaseNavigationViewController, View {
             }
             .disposed(by: self.disposeBag)
         
-        // 시간제한 카드 뷰 표시
+        // 시간제한 카드 뷰 및 태그 표시
         optionState
+            .skip(1)
             .compactMap { $0[.timeLimit] }
             .subscribe(with: self) { object, isTimeLimit in
                 
                 object.timeLimitBackgroundView.isHidden = isTimeLimit == false
+                
+                object.writeCardView.relatedTagsBackgroundView.isHidden = isTimeLimit
+                
                 object.writeCardView.writeTagTextField.isHidden = isTimeLimit
                 object.writeCardView.writtenTagsHeightConstraint?.deactivate()
                 object.writeCardView.writtenTags.snp.makeConstraints {
-                    let constraint = isTimeLimit ? $0.height.equalTo(0).constraint : $0.height.equalTo(12).constraint
+                    let height = self.writtenTagModels.isEmpty ? 12 : 58
+                    let constraint = isTimeLimit ? $0.height.equalTo(0).constraint : $0.height.equalTo(height).constraint
                     object.writeCardView.writtenTagsHeightConstraint = constraint
                 }
-            }
-            .disposed(by: self.disposeBag)
-        optionState
-            .compactMap { $0[.timeLimit] }
-            .map { !$0 }
-            .subscribe(with: self.writeCardView.writeTagTextField) { writeTagTextField, isTimeLimit in
-                writeTagTextField.isUserInteractionEnabled = isTimeLimit
-                writeTagTextField.text = nil
             }
             .disposed(by: self.disposeBag)
         

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewController.swift
@@ -134,6 +134,12 @@ class WriteCardViewController: BaseNavigationViewController, View {
         self.uploadCardBottomSheetViewController.reactor = self.reactor?.reactorForUploadCard()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        self.dismissBottomSheet()
+    }
+    
     
     // MARK: - ReactorKit - bind
     

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewReactor.swift
@@ -106,7 +106,7 @@ class WriteCardViewReactor: Reactor {
             
             let request: CardRequest = .writeComment(
                 id: self.cardIdForComment ?? "",
-                isDistanceShared: isDistanceShared,
+                isDistanceShared: !isDistanceShared,
                 latitude: coordinate.latitude,
                 longitude: coordinate.longitude,
                 content: trimedContent,

--- a/SOOUM/SOOUM/Presentations/Tags/Tags/Cells/FavoriteTag/FavoriteTagTableViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Tags/Tags/Cells/FavoriteTag/FavoriteTagTableViewCell.swift
@@ -102,5 +102,4 @@ extension FavoriteTagTableViewCell: UICollectionViewDelegate, UICollectionViewDa
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         return UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }
-    
 }

--- a/SOOUM/SOOUM/Resources/Alamofire/Develop/ReportRequest.swift
+++ b/SOOUM/SOOUM/Resources/Alamofire/Develop/ReportRequest.swift
@@ -14,6 +14,7 @@ enum ReportRequest: BaseRequest {
 
     case reportCard(id: String, reportType: ReportViewReactor.ReportType)
     case blockMember(id: String)
+    case cancelBlockMember(id: String)
     
 
     var path: String {
@@ -22,11 +23,15 @@ enum ReportRequest: BaseRequest {
             return "/report/cards/\(id)"
         case .blockMember:
             return "/blocks"
+        case let .cancelBlockMember(id):
+            return "/blocks/\(id)"
         }
     }
 
     var method: HTTPMethod {
         switch self {
+        case .cancelBlockMember:
+            return .delete
         default:
             return .post
         }
@@ -38,11 +43,15 @@ enum ReportRequest: BaseRequest {
             return ["reportType": reportType.rawValue]
         case let .blockMember(id):
             return ["toMemberId": id]
+        case .cancelBlockMember:
+            return [:]
         }
     }
 
     var encoding: ParameterEncoding {
         switch self {
+        case .cancelBlockMember:
+            return URLEncoding.default
         default:
             return JSONEncoding.default
         }

--- a/SOOUM/SOOUM/Utilities/SimpleCache.swift
+++ b/SOOUM/SOOUM/Utilities/SimpleCache.swift
@@ -1,0 +1,45 @@
+//
+//  SimpleCache.swift
+//  SOOUM
+//
+//  Created by 오현식 on 12/17/24.
+//
+
+import Foundation
+
+
+class SimpleCache {
+    
+    enum CardType: String {
+        case latest
+        case popular
+        case distance
+    }
+    
+    static let shared = SimpleCache()
+    
+    private let cache = NSCache<NSString, NSArray>()
+    
+    
+    // MARK: Main home
+    
+    private let mainHomeKey: String = "com.sooum.main.home"
+    
+    func loadMainHomeCards(type cardType: CardType) -> [Card]? {
+        let key: String = "\(self.mainHomeKey).\(cardType.rawValue)"
+        return self.cache.object(forKey: key as NSString) as? [Card]
+    }
+    
+    func saveMainHomeCards(type cardType: CardType, datas cards: [Card]) {
+        let key: String = "\(self.mainHomeKey).\(cardType.rawValue)"
+        self.cache.setObject(cards as NSArray, forKey: key as NSString)
+    }
+    
+    func isEmpty(type cardType: CardType) -> Bool {
+        return self.loadMainHomeCards(type: cardType) == nil
+    }
+    
+    func clear(type cardType: CardType) {
+        self.cache.removeAllObjects()
+    }
+}

--- a/SOOUM/SOOUM/Utilities/SimpleDefaults.swift
+++ b/SOOUM/SOOUM/Utilities/SimpleDefaults.swift
@@ -68,7 +68,7 @@ class SimpleDefaults {
     
     // MARK: Remote notification activation
     
-    private let remoteNotificationActivationKey: String = "kr.co.twinny.taras.remote.notification.activation"
+    private let remoteNotificationActivationKey: String = "remote.notification.activation"
 
     @discardableResult
     func initRemoteNotificationActivation() -> Bool {


### PR DESCRIPTION
<!--
  제목은 `[지라 작업번호] 작업 내용 요약`으로 작성해주세요.
-->

## 설명
### 작업 내용
<!-- 
  - PR 본문을 입력해주세요.
-->
1.4.1(104010) 피드백 반영
공통 사항
 - TableView/CollectionView 사용 화면 당겨서 새로고침 부드럽게 동작하도록 수정
 - 로딩 실패시 catchClousre 추가 -> 로딩 멈춤

메인 홈
 - 스크롤 시 데이터 바인딩 로직 수정
 - 메인 홈 리프레쉬 조건 추가
 - 스크롤이 필요하지 않을 때, 스크롤 제거

글추가
 - 바텀 싯 높이 조절 로직 수정
 - 거리 공유 옵션 바인딩 수정
 - 태그 입력/관련 태그 표시 로직 수정

프로필
 - 상대방 계정 차단 뷰 로직 수정
 - 프로필 피드 카드 글 정렬 수정
 - 프로필 버튼 들 throttle 시간 3 -> 1 로 수정
 - 설정 > 덧글 히스토리 상세보기 전환 가능하게 수정
 - 설정 > 이용약관 노션 링크 수정

## 참고 링크
<!--
  (Optional) 검토시 참고할 만한 자료를 공유해주세요.
  - 기획 문서, 디자인 문서, slack 메시지의 링크를 추가합니다.
  - 개발시 참고했던 기술 문서, article 등을 추가합니다.
-->
[104010 피드백](https://www.notion.so/0774d50e66804c70b3b8a3de3fbf9b2c?v=770cd8ec0bf047b7b5e73e271d5ad9f9&pvs=4)