### PR TITLE
1.5.1(105010) 버전 피드백 반영 (메인 홈, 글추가, 프로필)

### DIFF
--- a/SOOUM/SOOUM.xcodeproj/project.pbxproj
+++ b/SOOUM/SOOUM.xcodeproj/project.pbxproj
@@ -241,6 +241,8 @@
 		385620F32CA19D2D00E0AB5A /* Alamofire_Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385620F12CA19D2D00E0AB5A /* Alamofire_Request.swift */; };
 		385620F62CA19EA900E0AB5A /* Alamofire_constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385620F52CA19EA900E0AB5A /* Alamofire_constants.swift */; };
 		385620F72CA19EA900E0AB5A /* Alamofire_constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385620F52CA19EA900E0AB5A /* Alamofire_constants.swift */; };
+		38572CD82D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */; };
+		38572CD92D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */; };
 		385E65A32CBE56D00032E120 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385E65A22CBE56D00032E120 /* Coordinate.swift */; };
 		385E65A42CBE56D00032E120 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385E65A22CBE56D00032E120 /* Coordinate.swift */; };
 		38608B302CB5195D0066BB40 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38608B2F2CB5195D0066BB40 /* Card.swift */; };
@@ -612,6 +614,7 @@
 		385620EE2CA19C9500E0AB5A /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		385620F12CA19D2D00E0AB5A /* Alamofire_Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alamofire_Request.swift; sourceTree = "<group>"; };
 		385620F52CA19EA900E0AB5A /* Alamofire_constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alamofire_constants.swift; sourceTree = "<group>"; };
+		38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAllowResponse.swift; sourceTree = "<group>"; };
 		385E65A22CBE56D00032E120 /* Coordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinate.swift; sourceTree = "<group>"; };
 		38608B2F2CB5195D0066BB40 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		3862C0DE2C9EB6670023C046 /* UIViewController+PushAndPop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PushAndPop.swift"; sourceTree = "<group>"; };
@@ -1134,6 +1137,7 @@
 				3878D0552CFFCBDA00F9522F /* CommentHistoryResponse.swift */,
 				3803CF7C2D016DA200FD90DB /* TransferCodeResponse.swift */,
 				38FD4DAA2D032CF000BF5FF1 /* AnnouncementResponse.swift */,
+				38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -2277,6 +2281,7 @@
 				2AFD056A2D03264C007C84AD /* AddFavoriteTagResponse.swift in Sources */,
 				2AFD05532D007F2F007C84AD /* TagSearchViewReactor.swift in Sources */,
 				2A44A42B2CAC09AE00DC463E /* RSAKeyResponse.swift in Sources */,
+				38572CD92D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */,
 				382E15402D15AF4F0097B09C /* CommentHistoryInNotiResponse.swift in Sources */,
 				388698632D1986B100008600 /* NotificationRequest.swift in Sources */,
 				38C2D4152CFEA9CC00CEA092 /* MyProfileViewCell.swift in Sources */,
@@ -2501,6 +2506,7 @@
 				2AE6B15A2CBEAEC000FA5C3C /* ReportRequest.swift in Sources */,
 				38F70E682D191B3100B33C9D /* PlaceholderView.swift in Sources */,
 				388DA0FB2C8F521000A9DD56 /* FontContainer.swift in Sources */,
+				38572CD82D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */,
 				38D5637E2D17152F006265AA /* SOMSwipeTabBarDelegate.swift in Sources */,
 				2AE6B17B2CBFE9ED00FA5C3C /* UploadCardSettingTableViewCell.swift in Sources */,
 				38F70E5B2D1905D000B33C9D /* MainHomeTabBarController.swift in Sources */,

--- a/SOOUM/SOOUM.xcodeproj/project.pbxproj
+++ b/SOOUM/SOOUM.xcodeproj/project.pbxproj
@@ -2731,7 +2731,7 @@
 				CODE_SIGN_ENTITLEMENTS = "SOOUM/Resources/SOOUM-Dev.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105010;
+				CURRENT_PROJECT_VERSION = 105020;
 				DEVELOPMENT_TEAM = 99FRG743RX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SOOUM/Resources/Develop/Info-dev.plist";
@@ -2752,7 +2752,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D DEVELOP";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sooum.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2775,7 +2775,7 @@
 				CODE_SIGN_ENTITLEMENTS = "SOOUM/Resources/SOOUM-Dev.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105010;
+				CURRENT_PROJECT_VERSION = 105020;
 				DEVELOPMENT_TEAM = 99FRG743RX;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "SOOUM/Resources/Develop/Info-dev.plist";
@@ -2796,7 +2796,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.1;
+				MARKETING_VERSION = 1.5.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D DEVELOP";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sooum.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SOOUM/SOOUM.xcodeproj/project.pbxproj
+++ b/SOOUM/SOOUM.xcodeproj/project.pbxproj
@@ -245,6 +245,8 @@
 		38572CD92D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */; };
 		38572CDB2D22464F00B07C69 /* PungTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CDA2D22464F00B07C69 /* PungTimeView.swift */; };
 		38572CDC2D22464F00B07C69 /* PungTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CDA2D22464F00B07C69 /* PungTimeView.swift */; };
+		38572CDE2D2254E800B07C69 /* PlaceholderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CDD2D2254E800B07C69 /* PlaceholderViewCell.swift */; };
+		38572CDF2D2254E800B07C69 /* PlaceholderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CDD2D2254E800B07C69 /* PlaceholderViewCell.swift */; };
 		385E65A32CBE56D00032E120 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385E65A22CBE56D00032E120 /* Coordinate.swift */; };
 		385E65A42CBE56D00032E120 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385E65A22CBE56D00032E120 /* Coordinate.swift */; };
 		38608B302CB5195D0066BB40 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38608B2F2CB5195D0066BB40 /* Card.swift */; };
@@ -459,8 +461,6 @@
 		38F70E632D19113E00B33C9D /* MainHomeLatestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E612D19113E00B33C9D /* MainHomeLatestViewController.swift */; };
 		38F70E652D19161800B33C9D /* MainHomeLatestViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E642D19161800B33C9D /* MainHomeLatestViewReactor.swift */; };
 		38F70E662D19161800B33C9D /* MainHomeLatestViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E642D19161800B33C9D /* MainHomeLatestViewReactor.swift */; };
-		38F70E682D191B3100B33C9D /* PlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E672D191B3100B33C9D /* PlaceholderView.swift */; };
-		38F70E692D191B3100B33C9D /* PlaceholderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E672D191B3100B33C9D /* PlaceholderView.swift */; };
 		38F70E6C2D191D9A00B33C9D /* MainHomePopularViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E6B2D191D9A00B33C9D /* MainHomePopularViewController.swift */; };
 		38F70E6D2D191D9A00B33C9D /* MainHomePopularViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E6B2D191D9A00B33C9D /* MainHomePopularViewController.swift */; };
 		38F70E6F2D191DFB00B33C9D /* MainHomePopularViewReactor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F70E6E2D191DFB00B33C9D /* MainHomePopularViewReactor.swift */; };
@@ -618,6 +618,7 @@
 		385620F52CA19EA900E0AB5A /* Alamofire_constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alamofire_constants.swift; sourceTree = "<group>"; };
 		38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAllowResponse.swift; sourceTree = "<group>"; };
 		38572CDA2D22464F00B07C69 /* PungTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PungTimeView.swift; sourceTree = "<group>"; };
+		38572CDD2D2254E800B07C69 /* PlaceholderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderViewCell.swift; sourceTree = "<group>"; };
 		385E65A22CBE56D00032E120 /* Coordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinate.swift; sourceTree = "<group>"; };
 		38608B2F2CB5195D0066BB40 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		3862C0DE2C9EB6670023C046 /* UIViewController+PushAndPop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PushAndPop.swift"; sourceTree = "<group>"; };
@@ -732,7 +733,6 @@
 		38F70E5D2D190FBD00B33C9D /* MainHomeTabBarReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHomeTabBarReactor.swift; sourceTree = "<group>"; };
 		38F70E612D19113E00B33C9D /* MainHomeLatestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHomeLatestViewController.swift; sourceTree = "<group>"; };
 		38F70E642D19161800B33C9D /* MainHomeLatestViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHomeLatestViewReactor.swift; sourceTree = "<group>"; };
-		38F70E672D191B3100B33C9D /* PlaceholderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceholderView.swift; sourceTree = "<group>"; };
 		38F70E6B2D191D9A00B33C9D /* MainHomePopularViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHomePopularViewController.swift; sourceTree = "<group>"; };
 		38F70E6E2D191DFB00B33C9D /* MainHomePopularViewReactor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainHomePopularViewReactor.swift; sourceTree = "<group>"; };
 		38F7209A2CD4F15900DF32B5 /* CardSummaryResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardSummaryResponse.swift; sourceTree = "<group>"; };
@@ -1751,7 +1751,6 @@
 			isa = PBXGroup;
 			children = (
 				38B6AAD72CA424AE00CE6DB6 /* MoveTopButtonView.swift */,
-				38F70E672D191B3100B33C9D /* PlaceholderView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1808,6 +1807,7 @@
 			isa = PBXGroup;
 			children = (
 				38B8A5832CAE9CC4000AFE83 /* MainHomeViewCell.swift */,
+				38572CDD2D2254E800B07C69 /* PlaceholderViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -2292,7 +2292,6 @@
 				38F720B22CD4F15900DF32B5 /* distanceCardResponse.swift in Sources */,
 				38FD4DB52D034F6600BF5FF1 /* MyFollowerViewCell.swift in Sources */,
 				382E153B2D15A67A0097B09C /* NotificationViewCell.swift in Sources */,
-				38F70E692D191B3100B33C9D /* PlaceholderView.swift in Sources */,
 				388009922CABF855002A9209 /* SOMTagModel.swift in Sources */,
 				2AFD05502CFF79D8007C84AD /* TagsViewReactor.swift in Sources */,
 				3862C0E02C9EB6670023C046 /* UIViewController+PushAndPop.swift in Sources */,
@@ -2321,6 +2320,7 @@
 				38816D9F2D004A5E00EB87D6 /* UpdateProfileViewController.swift in Sources */,
 				38D6F1842CC243DB00E11530 /* UITextView+Typography.swift in Sources */,
 				2AFF95792CF5F0B000CBFB12 /* TagPreviewCardView.swift in Sources */,
+				38572CDF2D2254E800B07C69 /* PlaceholderViewCell.swift in Sources */,
 				38B6AACE2CA410D800CE6DB6 /* MainTabBarController.swift in Sources */,
 				2AE6B1512CBCC2F600FA5C3C /* ReportTableViewCell.swift in Sources */,
 				388371FD2C8C8F11004212EB /* UIColor+SOOUM.swift in Sources */,
@@ -2509,7 +2509,6 @@
 				2AFF95742CF5F08700CBFB12 /* TagPreviewCardCollectionViewCell.swift in Sources */,
 				2AFF95642CF33D9F00CBFB12 /* TagsHeaderView.swift in Sources */,
 				2AE6B15A2CBEAEC000FA5C3C /* ReportRequest.swift in Sources */,
-				38F70E682D191B3100B33C9D /* PlaceholderView.swift in Sources */,
 				388DA0FB2C8F521000A9DD56 /* FontContainer.swift in Sources */,
 				38572CD82D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */,
 				38D5637E2D17152F006265AA /* SOMSwipeTabBarDelegate.swift in Sources */,
@@ -2702,6 +2701,7 @@
 				2AFD05552D0082DE007C84AD /* SearchTagsResponse.swift in Sources */,
 				38B8A5882CAEA5F9000AFE83 /* DetailViewCell.swift in Sources */,
 				388698622D1986B100008600 /* NotificationRequest.swift in Sources */,
+				38572CDE2D2254E800B07C69 /* PlaceholderViewCell.swift in Sources */,
 				388009972CAC20EC002A9209 /* SOMTags+Rx.swift in Sources */,
 				388698542D191F4B00008600 /* MainHomeDistanceViewReactor.swift in Sources */,
 				3866577E2CEF3554009F7F60 /* UIButton+Rx.swift in Sources */,

--- a/SOOUM/SOOUM.xcodeproj/project.pbxproj
+++ b/SOOUM/SOOUM.xcodeproj/project.pbxproj
@@ -243,6 +243,8 @@
 		385620F72CA19EA900E0AB5A /* Alamofire_constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385620F52CA19EA900E0AB5A /* Alamofire_constants.swift */; };
 		38572CD82D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */; };
 		38572CD92D2230C900B07C69 /* NotificationAllowResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */; };
+		38572CDB2D22464F00B07C69 /* PungTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CDA2D22464F00B07C69 /* PungTimeView.swift */; };
+		38572CDC2D22464F00B07C69 /* PungTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38572CDA2D22464F00B07C69 /* PungTimeView.swift */; };
 		385E65A32CBE56D00032E120 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385E65A22CBE56D00032E120 /* Coordinate.swift */; };
 		385E65A42CBE56D00032E120 /* Coordinate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 385E65A22CBE56D00032E120 /* Coordinate.swift */; };
 		38608B302CB5195D0066BB40 /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38608B2F2CB5195D0066BB40 /* Card.swift */; };
@@ -615,6 +617,7 @@
 		385620F12CA19D2D00E0AB5A /* Alamofire_Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alamofire_Request.swift; sourceTree = "<group>"; };
 		385620F52CA19EA900E0AB5A /* Alamofire_constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alamofire_constants.swift; sourceTree = "<group>"; };
 		38572CD72D2230C900B07C69 /* NotificationAllowResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAllowResponse.swift; sourceTree = "<group>"; };
+		38572CDA2D22464F00B07C69 /* PungTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PungTimeView.swift; sourceTree = "<group>"; };
 		385E65A22CBE56D00032E120 /* Coordinate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinate.swift; sourceTree = "<group>"; };
 		38608B2F2CB5195D0066BB40 /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		3862C0DE2C9EB6670023C046 /* UIViewController+PushAndPop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+PushAndPop.swift"; sourceTree = "<group>"; };
@@ -1916,6 +1919,7 @@
 			children = (
 				381A1D682CC38E9B005FDB8E /* TextField */,
 				381A1D672CC38E8E005FDB8E /* TextView */,
+				38572CDA2D22464F00B07C69 /* PungTimeView.swift */,
 				3887D0352CC5335D00FB52E1 /* WriteCardView.swift */,
 			);
 			path = Views;
@@ -2402,6 +2406,7 @@
 				38C2D41B2CFEAAED00CEA092 /* ProfileViewFooter.swift in Sources */,
 				389681112CAFBD6A00FFD89F /* DetailViewReactor.swift in Sources */,
 				3878D0822CFFEC6900F9522F /* TermsOfServiceViewController.swift in Sources */,
+				38572CDC2D22464F00B07C69 /* PungTimeView.swift in Sources */,
 				38F720B92CD4F16500DF32B5 /* CardProtocol.swift in Sources */,
 				38121E352CA6DA4000602499 /* Date.swift in Sources */,
 				2A34AFB62D144F08007BD7E7 /* EmptyTagDetailTableViewCell.swift in Sources */,
@@ -2556,6 +2561,7 @@
 				2AFF955A2CF3227900CBFB12 /* TagSearchTextFieldView.swift in Sources */,
 				2A44A42D2CAC14C800DC463E /* SignInResponse.swift in Sources */,
 				38BE72172CC696E9002662DD /* WriteTagTextField+Rx.swift in Sources */,
+				38572CDB2D22464F00B07C69 /* PungTimeView.swift in Sources */,
 				38C2D41D2CFEB07900CEA092 /* ProfileViewFooterLayout.swift in Sources */,
 				381A1D772CC3DA99005FDB8E /* SOMTagsLayout.swift in Sources */,
 				38CC49882CDE3972007A0145 /* SOMPresentationController+Show.swift in Sources */,

--- a/SOOUM/SOOUM.xcodeproj/project.pbxproj
+++ b/SOOUM/SOOUM.xcodeproj/project.pbxproj
@@ -1885,8 +1885,8 @@
 			isa = PBXGroup;
 			children = (
 				38D5637D2D17152F006265AA /* SOMSwipeTabBarDelegate.swift */,
-				38D5637A2D16D72D006265AA /* SOMSwipeTabBar.swift */,
 				38D563832D1719B1006265AA /* SOMSwipeTabBarItem.swift */,
+				38D5637A2D16D72D006265AA /* SOMSwipeTabBar.swift */,
 			);
 			path = SOMSwipeTabBar;
 			sourceTree = "<group>";

--- a/SOOUM/SOOUM/App/AppDelegate.swift
+++ b/SOOUM/SOOUM/App/AppDelegate.swift
@@ -96,7 +96,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if let infoDic = userInfo as? [String: Any] {
             
             let info = NotificationInfo(infoDic)
-            PushManager.shared.setupRootViewController(info)
+            PushManager.shared.setupRootViewController(info, terminated: false)
         }
         
         // TODO: 알림으로 부터 받은 데이터 사용

--- a/SOOUM/SOOUM/App/AppDelegate.swift
+++ b/SOOUM/SOOUM/App/AppDelegate.swift
@@ -98,8 +98,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let info = NotificationInfo(infoDic)
             PushManager.shared.setupRootViewController(info, terminated: false)
         }
-        
-        // TODO: 알림으로 부터 받은 데이터 사용
 
         completionHandler()
     }

--- a/SOOUM/SOOUM/App/SceneDelegate.swift
+++ b/SOOUM/SOOUM/App/SceneDelegate.swift
@@ -36,7 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             if let infoDic: [String: Any] = userInfo as? [String: Any] {
                 
                 let info = NotificationInfo(infoDic)
-                PushManager.shared.setupRootViewController(info)
+                PushManager.shared.setupRootViewController(info, terminated: true)
             }
         }
     }

--- a/SOOUM/SOOUM/Base/BaseNavigationViewController.swift
+++ b/SOOUM/SOOUM/Base/BaseNavigationViewController.swift
@@ -106,6 +106,7 @@ class BaseNavigationViewController: BaseViewController {
         super.bind()
 
         self.navigationController?.delegate = self
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
 
         self.backButton.rx.tap
             .subscribe(with: self) { object, _ in

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMButton.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMButton.swift
@@ -63,12 +63,14 @@ class SOMButton: UIButton {
         var configuration = UIButton.Configuration.plain()
         
         // 이미지 설정
-        configuration.image = self.image
-        
-        if let foregroundColor = self.foregroundColor {
-            configuration.image?.withTintColor(foregroundColor)
-            configuration.imageColorTransformer = UIConfigurationColorTransformer { _ in
-                foregroundColor
+        if let image = self.image {
+            configuration.image = self.image
+            
+            if let foregroundColor = self.foregroundColor {
+                configuration.image?.withTintColor(foregroundColor)
+                configuration.imageColorTransformer = UIConfigurationColorTransformer { _ in
+                    foregroundColor
+                }
             }
         }
         

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
@@ -305,9 +305,9 @@ class SOMCard: UIView {
         }
         cardTextScrollView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(14)
+            $0.bottom.equalToSuperview().offset(-14)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalToSuperview().offset(-16)
-            $0.bottom.equalToSuperview().offset(-14)
         }
         cardTextContentLabel.snp.makeConstraints {
             $0.edges.equalToSuperview()

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
@@ -310,7 +310,7 @@ class SOMCard: UIView {
             $0.trailing.equalToSuperview().offset(-16)
         }
         cardTextContentLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.edges.equalTo(cardTextScrollView.contentLayoutGuide.snp.edges)
             $0.width.equalTo(cardTextScrollView.frameLayoutGuide.snp.width)
         }
         

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMCard/SOMCard.swift
@@ -170,7 +170,11 @@ class SOMCard: UIView {
     
     override func layoutSubviews() {
         super.layoutSubviews()
+        
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         cardGradientLayer.frame = cardGradientView.bounds
+        CATransaction.commit()
     }
     
     /// 이 컴포넌트를 사용하는 재사용 셀에서 호출

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMSwipeTabBar/SOMSwipeTabBar.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMSwipeTabBar/SOMSwipeTabBar.swift
@@ -165,7 +165,8 @@ class SOMSwipeTabBar: UIView {
             let item = SOMSwipeTabBarItem(title: title)
             item.updateState(
                 color: index == 0 ? self.selectedColor : self.defaultColor,
-                typo: index == 0 ? self.selectedTypo : self.defaultTypo
+                typo: index == 0 ? self.selectedTypo : self.defaultTypo,
+                with: 0
             )
             
             item.snp.makeConstraints {
@@ -198,13 +199,16 @@ class SOMSwipeTabBar: UIView {
         }
     }
     
-    func didSelectTabBarItem(_ index: Int) {
+    func didSelectTabBarItem(_ index: Int, animated: Bool = true) {
+        
+        let animationDuration: TimeInterval = animated ? 0.25 : 0
         
         self.tabBarItemContainer.arrangedSubviews.enumerated().forEach {
             let selectedItem = $1 as? SOMSwipeTabBarItem
             selectedItem?.updateState(
                 color: $0 == index ? self.selectedColor : self.defaultColor,
-                typo: $0 == index ? self.selectedTypo : self.defaultTypo
+                typo: $0 == index ? self.selectedTypo : self.defaultTypo,
+                with: $0 == index ? animationDuration : 0
             )
         }
         
@@ -216,7 +220,7 @@ class SOMSwipeTabBar: UIView {
                 self.selectedIndicatorLeadingConstraint = $0.leading.equalToSuperview().offset(indicatorLeadingOffset).constraint
             }
             
-            UIView.animate(withDuration: 0.25) {
+            UIView.animate(withDuration: animationDuration) {
                 self.layoutIfNeeded()
             }
         }

--- a/SOOUM/SOOUM/DesignSystem/Components/SOMSwipeTabBar/SOMSwipeTabBarItem.swift
+++ b/SOOUM/SOOUM/DesignSystem/Components/SOMSwipeTabBar/SOMSwipeTabBarItem.swift
@@ -39,9 +39,15 @@ class SOMSwipeTabBarItem: UIView {
         }
     }
     
-    func updateState(color textColor: UIColor, typo typography: Typography) {
+    func updateState(
+        color textColor: UIColor,
+        typo typography: Typography,
+        with duration: TimeInterval
+    ) {
         
-        self.titleLabel.textColor = textColor
-        self.titleLabel.typography = typography
+        UIView.animate(withDuration: duration) {
+            self.titleLabel.textColor = textColor
+            self.titleLabel.typography = typography
+        }
     }
 }

--- a/SOOUM/SOOUM/Extensions/Cocoa/UIImgeView.swift
+++ b/SOOUM/SOOUM/Extensions/Cocoa/UIImgeView.swift
@@ -19,12 +19,11 @@ extension UIImageView {
 
     func setImage(strUrl: String?) {
         
-        /// Image load
         if let strUrl: String = strUrl, let url = URL(string: strUrl) {
             self.kf.setImage(
                 with: url,
                 placeholder: Self.placeholder,
-                options: [.transition(.fade(0.5))]
+                options: [.transition(.fade(0.25))]
             )
             self.backgroundColor = .clear
         } else {

--- a/SOOUM/SOOUM/Managers/PushManager/Models/NotificationInfo.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/Models/NotificationInfo.swift
@@ -14,7 +14,8 @@ class NotificationInfo {
     let targetCardId: String?
     
     init(_ info: [String: Any]) {
-        self.notificationType = info["notificationType"] as? CommentHistoryInNoti.NotificationType
+        let notificationType = info["notificationType"] as? String ?? ""
+        self.notificationType = CommentHistoryInNoti.NotificationType(rawValue: notificationType)
         self.targetCardId = info["targetCardId"] as? String
     }
 }

--- a/SOOUM/SOOUM/Managers/PushManager/Models/NotificationInfo.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/Models/NotificationInfo.swift
@@ -11,11 +11,13 @@ import Foundation
 class NotificationInfo {
     
     let notificationType: CommentHistoryInNoti.NotificationType?
+    let notificationId: String?
     let targetCardId: String?
     
     init(_ info: [String: Any]) {
         let notificationType = info["notificationType"] as? String ?? ""
         self.notificationType = CommentHistoryInNoti.NotificationType(rawValue: notificationType)
+        self.notificationId = info["notificationId"] as? String
         self.targetCardId = info["targetCardId"] as? String
     }
 }

--- a/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
@@ -10,6 +10,9 @@ import UIKit
 
 protocol PushManagerDelegate: AnyObject {
     
+    var window: UIWindow? { get }
+    func setupRootViewController(_ info: NotificationInfo, terminated: Bool)
+    
     var canReceiveNotifications: Bool { get }
     var notificationStatus: Bool { get }
     func switchNotification(isOn: Bool, completion: ((Error?) -> Void)?)
@@ -49,7 +52,7 @@ class PushManager: NSObject, PushManagerDelegate {
         DispatchQueue.main.async { [weak self] in
             if self?.window != nil {
                 if terminated {
-                    
+                    self?.setupLaunchScreenViewController(info)
                 } else {
                     self?.setupMainTabBarController(info)
                 }

--- a/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
@@ -35,7 +35,9 @@ class PushManager: NSObject, PushManagerDelegate {
     override init() {
         super.init()
         
-        self.registerNotificationObserver()
+        // 설정 앱의 알림 허용 유무와 동기화 하는 옵저버 제거
+        // 서버 api를 통해서만 알림 허용 유무 변경
+        // self.registerNotificationObserver()
         self.updateNotificationStatus()
     }
     
@@ -105,15 +107,16 @@ class PushManager: NSObject, PushManagerDelegate {
 
             if isOn {
 
-                let appDelegate: AppDelegate? = application.delegate as? AppDelegate
-                appDelegate?.registerRemoteNotificationCompletion = { [weak self] error in
-                    if let error: Error = error {
-                        self?.notificationStatus = false
-                        completion?(error)
-                    } else {
-                        completion?(nil)
-                    }
-                }
+                // 서버 api를 통해서만 알림 허용 유무 변경
+                // let appDelegate: AppDelegate? = application.delegate as? AppDelegate
+                // appDelegate?.registerRemoteNotificationCompletion = { [weak self] error in
+                //     if let error: Error = error {
+                //         self?.notificationStatus = false
+                //         completion?(error)
+                //     } else {
+                //         completion?(nil)
+                //     }
+                // }
 
                 UNUserNotificationCenter.current().requestAuthorization(
                     options: [.alert, .badge, .sound],

--- a/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
@@ -44,22 +44,32 @@ class PushManager: NSObject, PushManagerDelegate {
     
     // MARK: Navigation
     
-    func setupRootViewController(_ info: NotificationInfo) {
+    func setupRootViewController(_ info: NotificationInfo, terminated: Bool) {
         
         DispatchQueue.main.async { [weak self] in
             if self?.window != nil {
-                self?.setupMainTabBarController(info)
+                if terminated {
+                    
+                } else {
+                    self?.setupMainTabBarController(info)
+                }
             }
         }
     }
     
+    fileprivate func setupLaunchScreenViewController(_ pushInfo: NotificationInfo) {
+        
+        let launchScreenReactor = LaunchScreenViewReactor(pushInfo: pushInfo)
+        let launchScreenViewController = LaunchScreenViewController()
+        launchScreenViewController.reactor = launchScreenReactor
+        
+        let navigationController = UINavigationController(rootViewController: launchScreenViewController)
+        self.window?.rootViewController = navigationController
+    }
+    
     fileprivate func setupMainTabBarController(_ pushInfo: NotificationInfo) {
         
-        let willNavigateNoti = pushInfo.notificationType == .blocked || pushInfo.notificationType == .delete
-        let mainTabBarReactor = MainTabBarReactor(
-            willNavigate: willNavigateNoti ? .pushForNoti : .pushForDetail,
-            pushInfo: pushInfo
-        )
+        let mainTabBarReactor = MainTabBarReactor(pushInfo: pushInfo)
         let mainTabBarController = MainTabBarController()
         mainTabBarController.reactor = mainTabBarReactor
         

--- a/SOOUM/SOOUM/Models/Profile/FollowingResponse.swift
+++ b/SOOUM/SOOUM/Models/Profile/FollowingResponse.swift
@@ -84,7 +84,10 @@ extension Follow {
 
 extension Follow {
     static func == (lhs: Follow, rhs: Follow) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id &&
+        lhs.nickname == rhs.nickname &&
+        lhs.backgroundImgURL == rhs.backgroundImgURL &&
+        lhs.isFollowing == rhs.isFollowing
     }
 }
 

--- a/SOOUM/SOOUM/Models/Settings/NotificationAllowResponse.swift
+++ b/SOOUM/SOOUM/Models/Settings/NotificationAllowResponse.swift
@@ -1,0 +1,32 @@
+//
+//  NotificationAllowResponse.swift
+//  SOOUM
+//
+//  Created by 오현식 on 12/30/24.
+//
+
+import Foundation
+
+import Alamofire
+
+
+struct NotificationAllowResponse: Codable {
+    
+    let isAllowNotify: Bool
+    let status: Status
+}
+
+extension NotificationAllowResponse {
+    
+    init() {
+        self.isAllowNotify = false
+        self.status = .init()
+    }
+}
+
+extension NotificationAllowResponse: EmptyResponse {
+    
+    static func emptyValue() -> NotificationAllowResponse {
+        NotificationAllowResponse.init()
+    }
+}

--- a/SOOUM/SOOUM/Presentations/Launch/LaunchScreenViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Launch/LaunchScreenViewReactor.swift
@@ -62,7 +62,9 @@ class LaunchScreenViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .launch:
-            return self.authManager.hasToken ? .just(.updateIsRegistered(true)) : self.login()
+            let autoLogin: Observable<Mutation> = .just(.updateIsRegistered(true))
+                .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+            return self.authManager.hasToken ? autoLogin : self.login()
         }
     }
     

--- a/SOOUM/SOOUM/Presentations/Launch/LaunchScreenViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Launch/LaunchScreenViewReactor.swift
@@ -53,7 +53,11 @@ class LaunchScreenViewReactor: Reactor {
     private let networkManager = NetworkManager.shared
     private let authManager = AuthManager.shared
     
-    init() { }
+    let pushInfo: NotificationInfo?
+    
+    init(pushInfo: NotificationInfo? = nil) {
+        self.pushInfo = pushInfo
+    }
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
@@ -88,6 +92,6 @@ extension LaunchScreenViewReactor {
 extension LaunchScreenViewReactor {
     
     func reactorForMainTabBar() -> MainTabBarReactor {
-        MainTabBarReactor(willNavigate: .none)
+        MainTabBarReactor(pushInfo: self.pushInfo)
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Cells/MainHomeViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Cells/MainHomeViewCell.swift
@@ -21,6 +21,7 @@ class MainHomeViewCell: UITableViewCell {
         self.selectionStyle = .none
         self.backgroundColor = .clear
         self.contentView.clipsToBounds = true
+        
         self.setupConstraints()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Home/Cells/MainHomeViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Cells/MainHomeViewCell.swift
@@ -20,7 +20,6 @@ class MainHomeViewCell: UITableViewCell {
         
         self.selectionStyle = .none
         self.backgroundColor = .clear
-        self.contentView.clipsToBounds = true
         
         self.setupConstraints()
     }
@@ -31,6 +30,7 @@ class MainHomeViewCell: UITableViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        
         self.cardView.prepareForReuse()
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Home/Cells/PlaceholderViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Cells/PlaceholderViewCell.swift
@@ -1,8 +1,8 @@
 //
-//  PlaceholderView.swift
+//  PlaceholderViewCell.swift
 //  SOOUM
 //
-//  Created by 오현식 on 12/23/24.
+//  Created by 오현식 on 12/30/24.
 //
 
 import UIKit
@@ -11,7 +11,7 @@ import SnapKit
 import Then
 
 
-class PlaceholderView: UIView {
+class PlaceholderViewCell: UITableViewCell {
     
     enum Text {
         static let title: String = "아직 등록된 카드가 없어요"
@@ -46,8 +46,12 @@ class PlaceholderView: UIView {
     
     // MARK: Initalization
     
-    override init(frame: CGRect) {
-        super.init(frame: .zero)
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        self.selectionStyle = .none
+        self.backgroundColor = .clear
+        self.isUserInteractionEnabled = false
         
         self.setupConstraints()
     }
@@ -61,21 +65,23 @@ class PlaceholderView: UIView {
     
     private func setupConstraints() {
         
-        self.addSubview(self.placeholderTitleLabel)
+        self.contentView.addSubview(self.placeholderTitleLabel)
         self.placeholderTitleLabel.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
+            let offset = UIScreen.main.bounds.height * 0.2
+            $0.top.equalToSuperview().offset(offset)
+            $0.centerX.equalToSuperview()
         }
         
-        self.addSubview(self.placeholderFirstSubTitleLabel)
+        self.contentView.addSubview(self.placeholderFirstSubTitleLabel)
         self.placeholderFirstSubTitleLabel.snp.makeConstraints {
             $0.top.equalTo(self.placeholderTitleLabel.snp.bottom).offset(14)
             $0.centerX.equalToSuperview()
         }
         
-        self.addSubview(self.placeholderSecondSubTitleLabel)
+        self.contentView.addSubview(self.placeholderSecondSubTitleLabel)
         self.placeholderSecondSubTitleLabel.snp.makeConstraints {
             $0.top.equalTo(self.placeholderFirstSubTitleLabel.snp.bottom)
-            $0.bottom.centerX.equalToSuperview()
+            $0.centerX.equalToSuperview()
         }
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/Cells/DetailViewFooter.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/Cells/DetailViewFooter.swift
@@ -162,6 +162,8 @@ extension DetailViewFooter: UICollectionViewDelegateFlowLayout {
         willDisplay cell: UICollectionViewCell,
         forItemAt indexPath: IndexPath
     ) {
+        guard self.commentCards.count == 1 else { return }
+        
         let layout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
         let cellWidthWithSpacing = cell.bounds.width + layout.minimumLineSpacing
         layout.sectionInset.left = (collectionView.bounds.width - cellWidthWithSpacing) * 0.5

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
@@ -347,18 +347,15 @@ extension DetailViewController: UICollectionViewDataSource {
             .subscribe(with: self) { object, _ in
                 if object.detailCard.isOwnCard {
                     
-                    let viewController = MainTabBarController()
-                    viewController.reactor = object.reactor?.reactorForMainTabBar()
-                    viewController.didSelectedIndex(3)
-                    let navigationController = UINavigationController(
-                        rootViewController: viewController
-                    )
-                    object.view.window?.rootViewController = navigationController
+                    let memberId = object.detailCard.member.id
+                    let profileViewController = ProfileViewController()
+                    profileViewController.reactor = object.reactor?.reactorForProfile(type: .myWithNavi, memberId)
+                    object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 } else {
                     
                     let memberId = object.detailCard.member.id
                     let profileViewController = ProfileViewController()
-                    profileViewController.reactor = object.reactor?.reactorForProfile(memberId)
+                    profileViewController.reactor = object.reactor?.reactorForProfile(type: .other, memberId)
                     object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 }
             }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
@@ -393,7 +393,7 @@ extension DetailViewController: UICollectionViewDataSource {
                 }
                 .disposed(by: footer.disposeBag)
             
-            footer.likeAndCommentView.likeBackgroundButton.rx.throttleTap(.seconds(3))
+            footer.likeAndCommentView.likeBackgroundButton.rx.throttleTap(.seconds(1))
                 .withLatestFrom(reactor.state.map(\.cardSummary.isLiked))
                 .subscribe(onNext: { isLike in
                     reactor.action.onNext(.updateLike(!isLike))

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewController.swift
@@ -245,6 +245,27 @@ class DetailViewController: BaseNavigationViewController, View {
                  object.navigationPop()
              }
              .disposed(by: self.disposeBag)
+         
+         reactor.state.map(\.errorMessage)
+             .distinctUntilChanged()
+             .skip(1)
+             .subscribe(with: self) { object, errorMessage in
+                 guard reactor.entranceType == .navi else {
+                     let notificationTabBarController = NotificationTabBarController()
+                     notificationTabBarController.reactor = reactor.reactorForNoti()
+                     
+                     object.navigationController?.pushViewController(notificationTabBarController, animated: false)
+                     object.navigationController?.viewControllers.removeAll(where: { $0.isKind(of: DetailViewController.self) })
+                     
+                     return
+                 }
+                 object.isDeleted = errorMessage != nil
+                 
+                 UIView.performWithoutAnimation {
+                     object.collectionView.reloadData()
+                 }
+             }
+             .disposed(by: self.disposeBag)
      }
  }
 

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewReactor.swift
@@ -198,7 +198,11 @@ extension DetailViewReactor {
     }
     
     func reactorForWriteCard() -> WriteCardViewReactor {
-        WriteCardViewReactor(type: .comment, self.selectedCardId)
+        WriteCardViewReactor(
+            type: .comment,
+            parentCardId: self.selectedCardId,
+            parentPungTime: self.currentState.detailCard.storyExpirationTime
+        )
     }
     
     func reactorForProfile(_ memberId: String) -> ProfileViewReactor {

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewReactor.swift
@@ -205,8 +205,11 @@ extension DetailViewReactor {
         )
     }
     
-    func reactorForProfile(_ memberId: String) -> ProfileViewReactor {
-        ProfileViewReactor.init(type: .other, memberId: memberId)
+    func reactorForProfile(
+        type: ProfileViewReactor.EntranceType,
+        _ memberId: String
+    ) -> ProfileViewReactor {
+        ProfileViewReactor.init(type: type, memberId: memberId)
     }
 }
 

--- a/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Detail/DetailViewReactor.swift
@@ -182,7 +182,7 @@ class DetailViewReactor: Reactor {
 extension DetailViewReactor {
     
     func reactorForMainTabBar() -> MainTabBarReactor {
-        MainTabBarReactor(willNavigate: .none)
+        MainTabBarReactor(pushInfo: nil)
     }
     
     func reactorForMainHome() -> MainHomeTabBarReactor {

--- a/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
@@ -282,10 +282,7 @@ extension MainHomeDistanceViewController: UITableViewDelegate {
         
         // offset이 currentOffset보다 크면 아래로 스크롤, 반대일 경우 위로 스크롤
         // 위로 스크롤 중일 때 헤더뷰 표시, 아래로 스크롤 중일 때 헤더뷰 숨김
-        // 메인 큐에서 실행 명시
-        DispatchQueue.main.async {
-            self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
-        }
+        self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
         
         self.currentOffset = offset
         

--- a/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
@@ -75,8 +75,8 @@ class MainHomeDistanceViewController: BaseViewController, View {
         self.view.addSubview(self.moveTopButton)
         self.view.bringSubviewToFront(self.moveTopButton)
         self.moveTopButton.snp.makeConstraints {
-            let bottomOffset: CGFloat = 24 + 60 + 4
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).offset(-bottomOffset)
+            let bottomOffset: CGFloat = 24 + 60 + 4 + 20
+            $0.bottom.equalTo(self.tableView.snp.bottom).offset(-bottomOffset)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(MoveTopButtonView.height)
         }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
@@ -102,7 +102,7 @@ class MainHomeDistanceViewController: BaseViewController, View {
         // Action
         self.rx.viewWillAppear
             .withUnretained(self)
-            .map { object, _ in object.isMovingToParent && object.isBeingPresented == false }
+            .map { object, _ in object.isViewLoaded == false }
             .map(Reactor.Action.landing)
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
@@ -129,6 +129,7 @@ class MainHomeDistanceViewController: BaseViewController, View {
         reactor.state.map(\.isProcessing)
             .distinctUntilChanged()
             .do(onNext: { [weak self] isProcessing in
+                self?.tableView.isHidden = isProcessing
                 if isProcessing == false { self?.isLoadingMore = false }
             })
             .bind(to: self.activityIndicatorView.rx.isAnimating)

--- a/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Distance/MainHomeDistanceViewController.swift
@@ -25,14 +25,14 @@ class MainHomeDistanceViewController: BaseViewController, View {
         $0.indicatorStyle = .black
         $0.separatorStyle = .none
         
+        $0.isHidden = true
+        
         $0.register(MainHomeViewCell.self, forCellReuseIdentifier: "cell")
         $0.register(PlaceholderViewCell.self, forCellReuseIdentifier: "placeholder")
         
         $0.refreshControl = SOMRefreshControl()
         
         $0.dataSource = self
-        $0.prefetchDataSource = self
-        
         $0.delegate = self
     }
     
@@ -142,6 +142,8 @@ class MainHomeDistanceViewController: BaseViewController, View {
                 let displayedCards = displayedCardsWithUpdate.cards
                 let isUpdate = displayedCardsWithUpdate.isUpdate
                 
+                object.tableView.isHidden = false
+                
                 // isUpdate == true 일 때, 추가된 카드만 로드
                 if isUpdate {
                     let indexPathForInsert: [IndexPath] = displayedCards.enumerated()
@@ -191,25 +193,6 @@ extension MainHomeDistanceViewController: UITableViewDataSource {
             cell.changeOrderInCardContentStack(2)
             
             return cell
-        }
-    }
-}
-
-extension MainHomeDistanceViewController: UITableViewDataSourcePrefetching {
-    
-    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
-        guard self.displayedCards.isEmpty == false else { return }
-        
-        if self.isLoadingMore == false,
-            let rowIndex = indexPaths.map({ $0.row }).max(),
-            rowIndex >= Int(Double(self.displayedCards.count) * 0.8),
-            let reactor = self.reactor {
-            
-            if let loadedCards = reactor.simpleCache.loadMainHomeCards(type: .latest),
-               self.displayedCards.count < loadedCards.count {
-                self.isLoadingMore = true
-                reactor.action.onNext(.moreFind(lastId: nil))
-            }
         }
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
@@ -26,6 +26,7 @@ class MainHomeLatestViewController: BaseViewController, View {
         $0.separatorStyle = .none
         
         $0.register(MainHomeViewCell.self, forCellReuseIdentifier: "cell")
+        $0.register(PlaceholderViewCell.self, forCellReuseIdentifier: "placeholder")
         
         $0.refreshControl = SOMRefreshControl()
         
@@ -38,8 +39,6 @@ class MainHomeLatestViewController: BaseViewController, View {
     private let moveTopButton = MoveTopButtonView().then {
         $0.isHidden = true
     }
-    
-    private let placeholderView = PlaceholderView()
     
     
     // MARK: Variables
@@ -74,13 +73,6 @@ class MainHomeLatestViewController: BaseViewController, View {
             $0.edges.equalToSuperview()
         }
         
-        self.view.addSubview(self.placeholderView)
-        self.placeholderView.snp.makeConstraints {
-            let offset = UIScreen.main.bounds.height * 0.4 - SOMSwipeTabBar.Height.mainHome
-            $0.top.equalToSuperview().offset(offset)
-            $0.centerX.equalToSuperview()
-        }
-        
         self.view.addSubview(self.moveTopButton)
         self.view.bringSubviewToFront(self.moveTopButton)
         self.moveTopButton.snp.makeConstraints {
@@ -109,11 +101,10 @@ class MainHomeLatestViewController: BaseViewController, View {
     func bind(reactor: MainHomeLatestViewReactor) {
         
         // Action
-        // 테이블 뷰가 스크롤이 되어 있을 시에 새로고침 X
         self.rx.viewWillAppear
             .withUnretained(self)
-            .filter { object, _ in object.tableView.contentOffset.y <= 0 }
-            .map { _ in Reactor.Action.landing }
+            .map { object, _ in object.isMovingToParent && object.isBeingPresented == false }
+            .map(Reactor.Action.landing)
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
@@ -135,37 +126,18 @@ class MainHomeLatestViewController: BaseViewController, View {
                 }
             }
             .disposed(by: self.disposeBag)
-        
-      let displayedCardsWithUpdate = reactor.state
-          .map(\.displayedCardsWithUpdate)
-          .distinctUntilChanged({ reactor.canUpdateCells(prev: $0, curr: $1) })
-          .share()
       
-        let isProcessing = reactor.state.map(\.isProcessing).distinctUntilChanged().share()
-        isProcessing
-            .filter { $0 }
-            .withLatestFrom(displayedCardsWithUpdate.map { $0.isUpdate })
-            .subscribe(with: self) { object, isUpdate in
-                object.tableView.isHidden = isUpdate == false
-                object.placeholderView.isHidden = true
-            }
-            .disposed(by: self.disposeBag)
-      
-        isProcessing
+        reactor.state.map(\.isProcessing)
             .distinctUntilChanged()
+            .do(onNext: { [weak self] isProcessing in
+                if isProcessing == false { self?.isLoadingMore = false }
+            })
             .bind(to: self.activityIndicatorView.rx.isAnimating)
             .disposed(by: self.disposeBag)
         
-        Observable.combineLatest(isProcessing, displayedCardsWithUpdate.map { $0.cards })
-            .filter { $0.0 == false }
-            .subscribe(with: self) { object, pair in
-                object.isLoadingMore = false
-                object.tableView.isHidden = pair.1.isEmpty
-                object.placeholderView.isHidden = pair.1.isEmpty == false
-            }
-            .disposed(by: self.disposeBag)
-        
-        displayedCardsWithUpdate
+        reactor.state.map(\.displayedCardsWithUpdate)
+            .distinctUntilChanged({ reactor.canUpdateCells(prev: $0, curr: $1) })
+            .skip(1)
             .subscribe(with: self) { object, displayedCardsWithUpdate in
                 let displayedCards = displayedCardsWithUpdate.cards
                 let isUpdate = displayedCardsWithUpdate.isUpdate
@@ -177,16 +149,10 @@ class MainHomeLatestViewController: BaseViewController, View {
                         .map { IndexPath(row: $0.offset, section: 0) }
                     
                     object.displayedCards = displayedCards
-                    
-                    object.tableView.performBatchUpdates {
-                        object.tableView.insertRows(at: indexPathForInsert, with: .automatic)
-                    }
+                    object.tableView.insertRows(at: indexPathForInsert, with: .fade)
                 } else {
                     object.displayedCards = displayedCards
-                    
-                    UIView.performWithoutAnimation {
-                        object.tableView.reloadData()
-                    }
+                    object.tableView.reloadData()
                 }
             }
             .disposed(by: self.disposeBag)
@@ -199,29 +165,40 @@ class MainHomeLatestViewController: BaseViewController, View {
 extension MainHomeLatestViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.displayedCards.count
+        return self.displayedCards.isEmpty ? 1 : self.displayedCards.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        let model = SOMCardModel(data: self.displayedCards[indexPath.row])
-        
-        let cell: MainHomeViewCell = tableView.dequeueReusableCell(
-            withIdentifier: "cell",
-            for: indexPath
-        ) as! MainHomeViewCell
-        cell.selectionStyle = .none
-        cell.setModel(model)
-        // 카드 하단 contents 스택 순서 변경 (최신순)
-        cell.changeOrderInCardContentStack(0)
-        
-        return cell
+        if self.displayedCards.isEmpty {
+            
+            let placeholder = tableView.dequeueReusableCell(
+                withIdentifier: "placeholder",
+                for: indexPath
+            ) as! PlaceholderViewCell
+            
+            return placeholder
+        } else {
+            
+            let model = SOMCardModel(data: self.displayedCards[indexPath.row])
+            
+            let cell: MainHomeViewCell = tableView.dequeueReusableCell(
+                withIdentifier: "cell",
+                for: indexPath
+            ) as! MainHomeViewCell
+            cell.setModel(model)
+            // 카드 하단 contents 스택 순서 변경 (최신순)
+            cell.changeOrderInCardContentStack(0)
+            
+            return cell
+        }
     }
 }
 
 extension MainHomeLatestViewController: UITableViewDataSourcePrefetching {
     
     func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        guard self.displayedCards.isEmpty == false else { return }
         
         if self.isLoadingMore == false,
            let rowIndex = indexPaths.map({ $0.row }).max(),
@@ -246,10 +223,12 @@ extension MainHomeLatestViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return self.cellHeight
+        return self.displayedCards.isEmpty ? self.tableView.bounds.height : self.cellHeight
     }
     
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard self.displayedCards.isEmpty == false else { return }
+        
         let lastSectionIndex = tableView.numberOfSections - 1
         let lastRowIndex = tableView.numberOfRows(inSection: lastSectionIndex) - 1
         
@@ -278,9 +257,22 @@ extension MainHomeLatestViewController: UITableViewDelegate {
         
         let offset = scrollView.contentOffset.y
         
+        // 당겨서 새로고침 상황일 때
+        if offset <= 0 {
+            
+            self.hidesHeaderContainer.accept(false)
+            self.currentOffset = offset
+            self.moveTopButton.isHidden = true
+            
+            return
+        }
+        
+        // 정상적인 스크롤 상황일 때, 헤더뷰 숨김
+        guard offset <= (scrollView.contentSize.height - scrollView.frame.height) else { return }
+        
         // offset이 currentOffset보다 크면 아래로 스크롤, 반대일 경우 위로 스크롤
         // 위로 스크롤 중일 때 헤더뷰 표시, 아래로 스크롤 중일 때 헤더뷰 숨김
-        self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
+        self.hidesHeaderContainer.accept(offset > self.currentOffset)
         
         self.currentOffset = offset
         

--- a/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
@@ -76,8 +76,8 @@ class MainHomeLatestViewController: BaseViewController, View {
         self.view.addSubview(self.moveTopButton)
         self.view.bringSubviewToFront(self.moveTopButton)
         self.moveTopButton.snp.makeConstraints {
-            let bottomOffset: CGFloat = 24 + 60 + 4
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).offset(-bottomOffset)
+            let bottomOffset: CGFloat = 24 + 60 + 4 + 20
+            $0.bottom.equalTo(self.tableView.snp.bottom).offset(-bottomOffset)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(MoveTopButtonView.height)
         }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
@@ -103,7 +103,7 @@ class MainHomeLatestViewController: BaseViewController, View {
         // Action
         self.rx.viewWillAppear
             .withUnretained(self)
-            .map { object, _ in object.isMovingToParent && object.isBeingPresented == false }
+            .map { object, _ in object.isViewLoaded == false }
             .map(Reactor.Action.landing)
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
@@ -130,6 +130,7 @@ class MainHomeLatestViewController: BaseViewController, View {
         reactor.state.map(\.isProcessing)
             .distinctUntilChanged()
             .do(onNext: { [weak self] isProcessing in
+                self?.tableView.isHidden = isProcessing
                 if isProcessing == false { self?.isLoadingMore = false }
             })
             .bind(to: self.activityIndicatorView.rx.isAnimating)

--- a/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewController.swift
@@ -280,10 +280,7 @@ extension MainHomeLatestViewController: UITableViewDelegate {
         
         // offset이 currentOffset보다 크면 아래로 스크롤, 반대일 경우 위로 스크롤
         // 위로 스크롤 중일 때 헤더뷰 표시, 아래로 스크롤 중일 때 헤더뷰 숨김
-        // 메인 큐에서 실행 명시
-        DispatchQueue.main.async {
-            self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
-        }
+        self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
         
         self.currentOffset = offset
         

--- a/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewReactor.swift
@@ -14,7 +14,7 @@ class MainHomeLatestViewReactor: Reactor {
     typealias CardsWithUpdate = (cards: [Card], isUpdate: Bool)
     
     enum Action: Equatable {
-        case landing
+        case landing(fromToParent: Bool)
         case refresh
         case moreFind(lastId: String?)
     }
@@ -48,22 +48,33 @@ class MainHomeLatestViewReactor: Reactor {
     
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case .landing:
+        case let .landing(fromToParent):
             
-            if self.simpleCache.isEmpty(type: .latest) {
-                // 캐시가 존재하지 않으면 서버 요청
-                return .concat([
-                    .just(.updateIsProcessing(true)),
-                    self.refresh()
-                        .delay(.milliseconds(500), scheduler: MainScheduler.instance),
-                    .just(.updateIsProcessing(false))
-                ])
-            } else {
-                // 캐시가 존재하면 캐싱된 데이터 사용
-                let cachedCards = self.simpleCache.loadMainHomeCards(type: .latest) ?? []
-                let displayedCards = self.separate(displayed: [], current: cachedCards)
+            // Navigation pop 으로 인한 표시이거나 (최우선),
+            // 캐시가 존재하지 않으면 서버 요청
+            if fromToParent {
                 
-                return .just(.cards((cards: displayedCards, isUpdate: false)))
+                // Pop 으로 인한 viewWillAppear 일 때, 딜레이 및 로딩 제거
+                return self.refresh()
+            } else {
+                
+                if self.simpleCache.isEmpty(type: .latest) {
+                    
+                    // 캐시가 존재하지 않을 떄
+                    return .concat([
+                        .just(.updateIsProcessing(true)),
+                        self.refresh()
+                            .delay(.milliseconds(500), scheduler: MainScheduler.instance),
+                        .just(.updateIsProcessing(false))
+                    ])
+                } else {
+                    
+                    // 캐시가 존재하면 캐싱된 데이터 사용
+                    let cachedCards = self.simpleCache.loadMainHomeCards(type: .latest) ?? []
+                    let displayedCards = self.separate(displayed: [], current: cachedCards)
+                    
+                    return .just(.cards((cards: displayedCards, isUpdate: false)))
+                }
             }
         case .refresh:
             return .concat([
@@ -163,6 +174,7 @@ extension MainHomeLatestViewReactor {
     var catchClosure: ((Error) throws -> Observable<Mutation> ) {
         return { _ in
             .concat([
+                .just(.cards((cards: [], isUpdate: false))),
                 .just(.updateIsProcessing(false)),
                 .just(.updateIsLoading(false))
             ])

--- a/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Latest/MainHomeLatestViewReactor.swift
@@ -16,7 +16,7 @@ class MainHomeLatestViewReactor: Reactor {
     enum Action: Equatable {
         case landing(fromToParent: Bool)
         case refresh
-        case moreFind(lastId: String?)
+        case moreFind(lastId: String)
     }
     
     enum Mutation {
@@ -43,7 +43,8 @@ class MainHomeLatestViewReactor: Reactor {
     
     let simpleCache = SimpleCache.shared
     
-    private let countPerLoading: Int = 10
+    // TODO: 페이징
+    // private let countPerLoading: Int = 10
     
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -71,9 +72,8 @@ class MainHomeLatestViewReactor: Reactor {
                     
                     // 캐시가 존재하면 캐싱된 데이터 사용
                     let cachedCards = self.simpleCache.loadMainHomeCards(type: .latest) ?? []
-                    let displayedCards = self.separate(displayed: [], current: cachedCards)
                     
-                    return .just(.cards((cards: displayedCards, isUpdate: false)))
+                    return .just(.cards((cards: cachedCards, isUpdate: false)))
                 }
             }
         case .refresh:
@@ -84,17 +84,6 @@ class MainHomeLatestViewReactor: Reactor {
                 .just(.updateIsLoading(false))
             ])
         case let .moreFind(lastId):
-            guard let lastId = lastId else {
-                // 캐시된 데이터가 존재할 때
-                let loadedCards = self.simpleCache.loadMainHomeCards(type: .latest) ?? []
-                let displayedCards = self.separate(
-                    displayed: self.currentState.displayedCardsWithUpdate.cards,
-                    current: loadedCards
-                )
-                
-                return .just(.more((cards: displayedCards, isUpdate: true)))
-            }
-            
             return .concat([
                 .just(.updateIsProcessing(true)),
                 self.moreFind(lastId)
@@ -137,9 +126,8 @@ extension MainHomeLatestViewReactor {
                 
                 // 서버 응답 캐싱
                 object.simpleCache.saveMainHomeCards(type: .latest, datas: cards)
-                // 표시할 데이터만 나누기
-                let displayedCards = object.separate(displayed: [], current: cards)
-                return .cards((cards: displayedCards, isUpdate: false))
+                
+                return .cards((cards: cards, isUpdate: false))
             }
             .catch(self.catchClosure)
     }
@@ -156,14 +144,13 @@ extension MainHomeLatestViewReactor {
             .withUnretained(self)
             .map { object, cards in
                 
-                let loadedCards = object.simpleCache.loadMainHomeCards(type: .latest) ?? []
-                var newCards = loadedCards
+                let cachedCards = object.simpleCache.loadMainHomeCards(type: .latest) ?? []
+                var newCards = cachedCards
                 newCards += cards
                 
                 object.simpleCache.saveMainHomeCards(type: .latest, datas: newCards)
                 
-                let displayedCards = object.separate(displayed: loadedCards, current: newCards)
-                return .more((cards: displayedCards, isUpdate: true))
+                return .more((cards: cards, isUpdate: true))
             }
             .catch(self.catchClosure)
     }
@@ -181,11 +168,12 @@ extension MainHomeLatestViewReactor {
         }
     }
     
-    func separate(displayed displayedCards: [Card], current cards: [Card]) -> [Card] {
-        let count = displayedCards.count
-        let displayedCards = Array(cards[count..<min(count + self.countPerLoading, cards.count)])
-        return displayedCards
-    }
+    // TODO: 페이징
+    // func separate(displayed displayedCards: [Card], current cards: [Card]) -> [Card] {
+    //     let count = displayedCards.count
+    //     let displayedCards = Array(cards[count..<min(count + self.countPerLoading, cards.count)])
+    //     return displayedCards
+    // }
   
     func canUpdateCells(
         prev prevCardsWithUpdate: CardsWithUpdate,

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarController.swift
@@ -40,6 +40,13 @@ class MainHomeTabBarController: BaseNavigationViewController, View {
         $0.foregroundColor = .som.gray700
     }
     
+    private let dotWithoutReadView = UIView().then {
+        $0.backgroundColor = .som.red
+        $0.layer.cornerRadius = 6 * 0.5
+        $0.clipsToBounds = true
+        $0.isHidden = true
+    }
+    
     
     // MARK: Views
     
@@ -92,6 +99,12 @@ class MainHomeTabBarController: BaseNavigationViewController, View {
         self.navigationBar.hidesBackButton = true
         self.rightAlamButton.snp.makeConstraints {
             $0.size.equalTo(24)
+        }
+        self.rightAlamButton.addSubview(self.dotWithoutReadView)
+        self.dotWithoutReadView.snp.makeConstraints {
+            $0.top.equalTo(self.rightAlamButton.snp.top).offset(2)
+            $0.trailing.equalTo(self.rightAlamButton.snp.trailing).offset(-3)
+            $0.size.equalTo(6)
         }
         self.navigationBar.setRightButtons([self.rightAlamButton])
     }
@@ -238,6 +251,18 @@ class MainHomeTabBarController: BaseNavigationViewController, View {
             object.navigationPush(detailViewController, animated: true, bottomBarHidden: true)
         }
         .disposed(by: self.disposeBag)
+        
+        // Action
+        self.rx.viewWillAppear
+            .map { _ in Reactor.Action.notisWithoutRead }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
+        // State
+        reactor.state.map(\.isNotisWithoutRead)
+            .distinctUntilChanged()
+            .bind(to: self.dotWithoutReadView.rx.isHidden)
+            .disposed(by: self.disposeBag)
     }
 }
 

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarController.swift
@@ -189,6 +189,7 @@ class MainHomeTabBarController: BaseNavigationViewController, View {
             mainHomePopularViewController.hidesHeaderContainer.asObservable(),
             mainHomeDistanceViewController.hidesHeaderContainer.asObservable()
         )
+        .observe(on: MainScheduler.instance)
         .subscribe(with: self) { object, hidesHeaderContainer in
             
             // 위로 스크롤 중일 때 헤더뷰 표시, 아래로 스크롤 중일 때 헤더뷰 숨김

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarController.swift
@@ -88,6 +88,9 @@ class MainHomeTabBarController: BaseNavigationViewController, View {
         self.navigationBar.titlePosition = .left
         
         self.navigationBar.hidesBackButton = true
+        self.rightAlamButton.snp.makeConstraints {
+            $0.size.equalTo(24)
+        }
         self.navigationBar.setRightButtons([self.rightAlamButton])
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarReactor.swift
@@ -10,16 +10,43 @@ import ReactorKit
 
 class MainHomeTabBarReactor: Reactor {
 
-    typealias Action = NoAction
-    typealias Mutation = NoMutation
-    
-    struct State { }
-    
-    var initialState: State {
-        .init()
+    enum Action: Equatable {
+        case notisWithoutRead
     }
     
+    
+    enum Mutation {
+        case notisWithoutRead(Bool)
+    }
+    
+    struct State {
+        var isNotisWithoutRead: Bool
+    }
+    
+    var initialState: State = .init(isNotisWithoutRead: false)
+    
+    private let networkManager = NetworkManager.shared
     let locationManager = LocationManager.shared
+    
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .notisWithoutRead:
+            let request: NotificationRequest = .totalWithoutRead(lastId: nil)
+            
+            return self.networkManager.request(CommentHistoryInNotiResponse.self, request: request)
+                .map { $0.commentHistoryInNotis.isEmpty }
+                .map(Mutation.notisWithoutRead)
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var state = state
+        switch mutation {
+        case let .notisWithoutRead(isNotisWithoutRead):
+            state.isNotisWithoutRead = isNotisWithoutRead
+        }
+        return state
+    }
 }
 
 extension MainHomeTabBarReactor {

--- a/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/MainHomeTabBarReactor.swift
@@ -7,23 +7,31 @@
 
 import ReactorKit
 
+import Alamofire
+
 
 class MainHomeTabBarReactor: Reactor {
 
     enum Action: Equatable {
         case notisWithoutRead
+        case requestRead(String)
     }
     
     
     enum Mutation {
         case notisWithoutRead(Bool)
+        case updateIsReadCompleted(Bool)
     }
     
     struct State {
         var isNotisWithoutRead: Bool
+        var isReadCompleted: Bool
     }
     
-    var initialState: State = .init(isNotisWithoutRead: false)
+    var initialState: State = .init(
+        isNotisWithoutRead: false,
+        isReadCompleted: false
+    )
     
     private let networkManager = NetworkManager.shared
     let locationManager = LocationManager.shared
@@ -36,6 +44,10 @@ class MainHomeTabBarReactor: Reactor {
             return self.networkManager.request(CommentHistoryInNotiResponse.self, request: request)
                 .map { $0.commentHistoryInNotis.isEmpty }
                 .map(Mutation.notisWithoutRead)
+        case let .requestRead(selectedId):
+            let request: NotificationRequest = .requestRead(notificationId: selectedId)
+            return self.networkManager.request(Empty.self, request: request)
+                .map { _ in .updateIsReadCompleted(true) }
         }
     }
     
@@ -44,6 +56,8 @@ class MainHomeTabBarReactor: Reactor {
         switch mutation {
         case let .notisWithoutRead(isNotisWithoutRead):
             state.isNotisWithoutRead = isNotisWithoutRead
+        case let .updateIsReadCompleted(isReadCompleted):
+            state.isReadCompleted = isReadCompleted
         }
         return state
     }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
@@ -75,8 +75,8 @@ class MainHomePopularViewController: BaseViewController, View {
         self.view.addSubview(self.moveTopButton)
         self.view.bringSubviewToFront(self.moveTopButton)
         self.moveTopButton.snp.makeConstraints {
-            let bottomOffset: CGFloat = 24 + 60 + 4
-            $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).offset(-bottomOffset)
+            let bottomOffset: CGFloat = 24 + 60 + 4 + 20
+            $0.bottom.equalTo(self.tableView.snp.bottom).offset(-bottomOffset)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(MoveTopButtonView.height)
         }

--- a/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
@@ -257,10 +257,7 @@ extension MainHomePopularViewController: UITableViewDelegate {
         
         // offset이 currentOffset보다 크면 아래로 스크롤, 반대일 경우 위로 스크롤
         // 위로 스크롤 중일 때 헤더뷰 표시, 아래로 스크롤 중일 때 헤더뷰 숨김
-        // 메인 큐에서 실행 명시
-        DispatchQueue.main.async {
-            self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
-        }
+        self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
         
         self.currentOffset = offset
         

--- a/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
@@ -26,6 +26,7 @@ class MainHomePopularViewController: BaseViewController, View {
         $0.separatorStyle = .none
         
         $0.register(MainHomeViewCell.self, forCellReuseIdentifier: "cell")
+        $0.register(PlaceholderViewCell.self, forCellReuseIdentifier: "placeholder")
         
         $0.refreshControl = SOMRefreshControl()
         
@@ -38,8 +39,6 @@ class MainHomePopularViewController: BaseViewController, View {
     private let moveTopButton = MoveTopButtonView().then {
         $0.isHidden = true
     }
-    
-    private let placeholderView = PlaceholderView()
     
     
     // MARK: Variables
@@ -73,13 +72,6 @@ class MainHomePopularViewController: BaseViewController, View {
             $0.edges.equalToSuperview()
         }
         
-        self.view.addSubview(self.placeholderView)
-        self.placeholderView.snp.makeConstraints {
-            let offset = UIScreen.main.bounds.height * 0.4 - SOMSwipeTabBar.Height.mainHome
-            $0.top.equalToSuperview().offset(offset)
-            $0.centerX.equalToSuperview()
-        }
-        
         self.view.addSubview(self.moveTopButton)
         self.view.bringSubviewToFront(self.moveTopButton)
         self.moveTopButton.snp.makeConstraints {
@@ -108,10 +100,9 @@ class MainHomePopularViewController: BaseViewController, View {
     func bind(reactor: MainHomePopularViewReactor) {
         
         // Action
-        // 테이블 뷰가 스크롤이 되어 있을 시에 새로고침 X
         self.rx.viewWillAppear
             .withUnretained(self)
-            .filter { object, _ in object.tableView.contentOffset.y <= 0 }
+            .map { object, _ in object.isMovingToParent && object.isBeingPresented == false }
             .map { _ in Reactor.Action.landing }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
@@ -134,37 +125,20 @@ class MainHomePopularViewController: BaseViewController, View {
                 }
             }
             .disposed(by: self.disposeBag)
-        
-      let displayedCardsWithUpdate = reactor.state
-          .map(\.displayedCardsWithUpdate)
-          .distinctUntilChanged({ reactor.canUpdateCells(prev: $0, curr: $1) })
-          .share()
       
         let isProcessing = reactor.state.map(\.isProcessing).distinctUntilChanged().share()
         isProcessing
-            .filter { $0 }
-            .withLatestFrom(displayedCardsWithUpdate.map { $0.isUpdate })
-            .subscribe(with: self) { object, isUpdate in
-                object.tableView.isHidden = isUpdate == false
-                object.placeholderView.isHidden = true
-            }
-            .disposed(by: self.disposeBag)
-      
-        isProcessing
-            .distinctUntilChanged()
             .bind(to: self.activityIndicatorView.rx.isAnimating)
             .disposed(by: self.disposeBag)
-        
-        Observable.combineLatest(isProcessing, displayedCardsWithUpdate.map { $0.cards })
-            .filter { $0.0 == false }
-            .subscribe(with: self) { object, pair in
-                object.tableView.isHidden = pair.1.isEmpty
-                object.placeholderView.isHidden = pair.1.isEmpty == false
-            }
+        isProcessing
+            .bind(to: self.tableView.rx.isHidden)
             .disposed(by: self.disposeBag)
         
-        displayedCardsWithUpdate
+        reactor.state.map(\.displayedCardsWithUpdate)
+            .distinctUntilChanged({ reactor.canUpdateCells(prev: $0, curr: $1) })
+            .skip(1)
             .subscribe(with: self) { object, displayedCardsWithUpdate in
+                
                 let displayedCards = displayedCardsWithUpdate.cards
                 let isUpdate = displayedCardsWithUpdate.isUpdate
                 
@@ -175,16 +149,10 @@ class MainHomePopularViewController: BaseViewController, View {
                         .map { IndexPath(row: $0.offset, section: 0) }
                     
                     object.displayedCards = displayedCards
-                    
-                    object.tableView.performBatchUpdates {
-                        object.tableView.insertRows(at: indexPathForInsert, with: .automatic)
-                    }
+                    object.tableView.insertRows(at: indexPathForInsert, with: .fade)
                 } else {
                     object.displayedCards = displayedCards
-                    
-                    UIView.performWithoutAnimation {
-                        object.tableView.reloadData()
-                    }
+                    object.tableView.reloadData()
                 }
             }
             .disposed(by: self.disposeBag)
@@ -197,23 +165,33 @@ class MainHomePopularViewController: BaseViewController, View {
 extension MainHomePopularViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.displayedCards.count
+        return self.displayedCards.isEmpty ? 1 : self.displayedCards.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        let model = SOMCardModel(data: self.displayedCards[indexPath.row])
-        
-        let cell: MainHomeViewCell = tableView.dequeueReusableCell(
-            withIdentifier: "cell",
-            for: indexPath
-        ) as! MainHomeViewCell
-        cell.selectionStyle = .none
-        cell.setModel(model)
-        // 카드 하단 contents 스택 순서 변경 (인기순)
-        cell.changeOrderInCardContentStack(1)
-        
-        return cell
+        if self.displayedCards.isEmpty {
+            
+            let placeholder = tableView.dequeueReusableCell(
+                withIdentifier: "placeholder",
+                for: indexPath
+            ) as! PlaceholderViewCell
+            
+            return placeholder
+        } else {
+            
+            let model = SOMCardModel(data: self.displayedCards[indexPath.row])
+            
+            let cell: MainHomeViewCell = tableView.dequeueReusableCell(
+                withIdentifier: "cell",
+                for: indexPath
+            ) as! MainHomeViewCell
+            cell.setModel(model)
+            // 카드 하단 contents 스택 순서 변경 (인기순)
+            cell.changeOrderInCardContentStack(1)
+            
+            return cell
+        }
     }
 }
 
@@ -242,7 +220,7 @@ extension MainHomePopularViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return self.cellHeight
+        return self.displayedCards.isEmpty ? self.tableView.bounds.height : self.cellHeight
     }
     
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
@@ -255,9 +233,21 @@ extension MainHomePopularViewController: UITableViewDelegate {
         
         let offset = scrollView.contentOffset.y
         
+        // 당겨서 새로고침 상황일 때
+        if offset <= 0 {
+            
+            self.hidesHeaderContainer.accept(false)
+            self.currentOffset = offset
+            
+            self.moveTopButton.isHidden = true
+            return
+        }
+        
+        guard offset <= (scrollView.contentSize.height - scrollView.frame.height) else { return }
+        
         // offset이 currentOffset보다 크면 아래로 스크롤, 반대일 경우 위로 스크롤
         // 위로 스크롤 중일 때 헤더뷰 표시, 아래로 스크롤 중일 때 헤더뷰 숨김
-        self.hidesHeaderContainer.accept(offset <= 0 ? false : offset > self.currentOffset)
+        self.hidesHeaderContainer.accept(offset > self.currentOffset)
         
         self.currentOffset = offset
         

--- a/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Popular/MainHomePopularViewController.swift
@@ -102,7 +102,7 @@ class MainHomePopularViewController: BaseViewController, View {
         // Action
         self.rx.viewWillAppear
             .withUnretained(self)
-            .map { object, _ in object.isMovingToParent && object.isBeingPresented == false }
+            .map { object, _ in object.isViewLoaded == false }
             .map { _ in Reactor.Action.landing }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)

--- a/SOOUM/SOOUM/Presentations/Main/MainTabBarController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/MainTabBarController.swift
@@ -120,11 +120,11 @@ class MainTabBarController: SOMTabBarController, View {
                 switch entranceType {
                 case .pushForNoti:
                     
-                    let notificationViewController = NotificationViewController()
-                    notificationViewController.reactor = reactor.reactorForNoti()
+                    let notificationTabBarController = NotificationTabBarController()
+                    notificationTabBarController.reactor = reactor.reactorForNoti()
                     mainHomeTabBarController.navigationPush(
-                        notificationViewController,
-                        animated: true,
+                        notificationTabBarController,
+                        animated: false,
                         bottomBarHidden: true
                     )
                 case .pushForDetail:
@@ -133,7 +133,7 @@ class MainTabBarController: SOMTabBarController, View {
                     detailViewController.reactor = reactor.reactorForDetail(targetCardId)
                     mainHomeTabBarController.navigationPush(
                         detailViewController,
-                        animated: true,
+                        animated: false,
                         bottomBarHidden: true
                     )
                 default: break

--- a/SOOUM/SOOUM/Presentations/Main/MainTabBarController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/MainTabBarController.swift
@@ -109,19 +109,33 @@ class MainTabBarController: SOMTabBarController, View {
             .distinctUntilChanged()
             .subscribe(with: self) { object, entranceType in
                 
+                guard let navigationController = object.viewControllers[0] as? UINavigationController,
+                      let mainHomeTabBarController = navigationController.viewControllers.first as? MainHomeTabBarController,
+                      let targetCardId = reactor.pushInfo?.targetCardId,
+                      let notificationId = reactor.pushInfo?.notificationId
+                else { return }
+                
+                mainHomeTabBarController.reactor?.action.onNext(.requestRead(notificationId))
+                
                 switch entranceType {
                 case .pushForNoti:
                     
                     let notificationViewController = NotificationViewController()
                     notificationViewController.reactor = reactor.reactorForNoti()
-                    object.navigationPush(notificationViewController, animated: true, bottomBarHidden: true)
+                    mainHomeTabBarController.navigationPush(
+                        notificationViewController,
+                        animated: true,
+                        bottomBarHidden: true
+                    )
                 case .pushForDetail:
-                    
-                    guard let targetCardId = reactor.pushInfo?.targetCardId else { return }
                     
                     let detailViewController = DetailViewController()
                     detailViewController.reactor = reactor.reactorForDetail(targetCardId)
-                    object.navigationPush(detailViewController, animated: true, bottomBarHidden: true)
+                    mainHomeTabBarController.navigationPush(
+                        detailViewController,
+                        animated: true,
+                        bottomBarHidden: true
+                    )
                 default: break
                 }
             }

--- a/SOOUM/SOOUM/Presentations/Main/MainTabBarReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/MainTabBarReactor.swift
@@ -82,11 +82,11 @@ extension MainTabBarReactor {
         ProfileViewReactor(type: .my, memberId: nil)
     }
     
-    func reactorForNoti() -> NotificationViewReactor {
-        NotificationViewReactor(.total)
+    func reactorForNoti() -> NotificationTabBarReactor {
+        NotificationTabBarReactor()
     }
     
     func reactorForDetail(_ targetCardId: String) -> DetailViewReactor {
-        DetailViewReactor(targetCardId)
+        DetailViewReactor(type: .push, targetCardId)
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/MainTabBarReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/MainTabBarReactor.swift
@@ -36,7 +36,17 @@ class MainTabBarReactor: Reactor {
     private let willNavigate: EntranceType
     let pushInfo: NotificationInfo?
     
-    init(willNavigate: EntranceType, pushInfo: NotificationInfo? = nil) {
+    init(pushInfo: NotificationInfo? = nil) {
+        var willNavigate: EntranceType {
+            switch pushInfo?.notificationType {
+            case .feedLike, .commentLike, .commentWrite:
+                return .pushForDetail
+            case .blocked, .delete:
+                return .pushForNoti
+            default:
+                return .none
+            }
+        }
         self.willNavigate = willNavigate
         self.pushInfo = pushInfo
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowerViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowerViewCell.swift
@@ -106,12 +106,18 @@ class MyFollowerViewCell: UITableViewCell {
     // MARK: Public func
     
     func setModel(_ follow: Follow) {
-        if let url = follow.backgroundImgURL?.url {
-            self.profileImageView.setImage(strUrl: url)
-        } else {
-            self.profileImageView.image = .init(.image(.sooumLogo))
+        
+        if self.profileImageView.image == nil {
+            if let url = follow.backgroundImgURL?.url {
+                self.profileImageView.setImage(strUrl: url)
+            } else {
+                self.profileImageView.image = .init(.image(.sooumLogo))
+            }
         }
-        self.profileNickname.text = follow.nickname
+        
+        if self.profileNickname.text != follow.nickname {
+            self.profileNickname.text = follow.nickname
+        }
         
         self.updateButton(follow.isFollowing)
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowingViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/MyFollowingViewCell.swift
@@ -127,12 +127,18 @@ class MyFollowingViewCell: UITableViewCell {
     // MARK: Public func
     
     func setModel(_ follow: Follow) {
-        if let url = follow.backgroundImgURL?.url {
-            self.profileImageView.setImage(strUrl: url)
-        } else {
-            self.profileImageView.image = .init(.image(.sooumLogo))
+        
+        if self.profileImageView.image == nil {
+            if let url = follow.backgroundImgURL?.url {
+                self.profileImageView.setImage(strUrl: url)
+            } else {
+                self.profileImageView.image = .init(.image(.sooumLogo))
+            }
         }
-        self.profileNickname.text = follow.nickname
+        
+        if self.profileNickname.text != follow.nickname {
+            self.profileNickname.text = follow.nickname
+        }
         
         self.updateButton(follow.isFollowing)
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
@@ -106,12 +106,18 @@ class OtherFollowViewCell: UITableViewCell {
     // MARK: Public func
     
     func setModel(_ follow: Follow) {
-        if let url = follow.backgroundImgURL?.url {
-            self.profileImageView.setImage(strUrl: url)
-        } else {
-            self.profileImageView.image = .init(.image(.sooumLogo))
+        
+        if self.profileImageView.image == nil {
+            if let url = follow.backgroundImgURL?.url {
+                self.profileImageView.setImage(strUrl: url)
+            } else {
+                self.profileImageView.image = .init(.image(.sooumLogo))
+            }
         }
-        self.profileNickname.text = follow.nickname
+        
+        if self.profileNickname.text != follow.nickname {
+            self.profileNickname.text = follow.nickname
+        }
         
         self.updateButton(follow.isFollowing)
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
@@ -119,7 +119,12 @@ class OtherFollowViewCell: UITableViewCell {
             self.profileNickname.text = follow.nickname
         }
         
-        self.updateButton(follow.isFollowing)
+        
+        if follow.isRequester {
+            self.followButton.isHidden = true
+        } else {
+            self.updateButton(follow.isFollowing)
+        }
     }
     
     func updateButton(_ isFollowing: Bool) {

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/Cells/OtherFollowViewCell.swift
@@ -34,7 +34,7 @@ class OtherFollowViewCell: UITableViewCell {
         $0.typography = .som.body1WithBold
     }
     
-    private let followButton = SOMButton().then {
+    let followButton = SOMButton().then {
         $0.layer.cornerRadius = 26 * 0.5
         $0.clipsToBounds = true
     }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
@@ -114,6 +114,20 @@ class FollowViewController: BaseNavigationViewController, View {
                 object.tableView.reloadData()
             }
             .disposed(by: self.disposeBag)
+        
+        reactor.state.map(\.isRequest)
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in Reactor.Action.landing }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
+        
+        reactor.state.map(\.isCancel)
+            .distinctUntilChanged()
+            .filter { $0 }
+            .map { _ in Reactor.Action.landing }
+            .bind(to: reactor.action)
+            .disposed(by: self.disposeBag)
     }
 }
 
@@ -183,6 +197,7 @@ extension FollowViewController {
         ) as! MyFollowingViewCell
         cell.selectionStyle = .none
         cell.setModel(model)
+        cell.updateButton(model.isFollowing)
         
         cell.profilBackgroundButton.rx.tap
             .subscribe(with: self) { object, _ in
@@ -207,14 +222,12 @@ extension FollowViewController {
         
         cell.cancelFollowButton.rx.throttleTap(.seconds(1))
             .subscribe(onNext: { _ in
-                cell.updateButton(false)
                 reactor.action.onNext(.cancel(model.id))
             })
             .disposed(by: cell.disposeBag)
         
         cell.followButton.rx.throttleTap(.seconds(1))
             .subscribe(onNext: { _ in
-                cell.updateButton(true)
                 reactor.action.onNext(.request(model.id))
             })
             .disposed(by: cell.disposeBag)
@@ -232,6 +245,7 @@ extension FollowViewController {
         ) as! MyFollowerViewCell
         cell.selectionStyle = .none
         cell.setModel(model)
+        cell.updateButton(model.isFollowing)
         
         cell.profilBackgroundButton.rx.tap
             .subscribe(with: self) { object, _ in
@@ -256,7 +270,6 @@ extension FollowViewController {
         
         cell.followButton.rx.throttleTap(.seconds(1))
             .subscribe(onNext: { _ in
-                cell.updateButton(!model.isFollowing)
                 reactor.action.onNext(model.isFollowing ? .cancel(model.id) : .request(model.id))
             })
             .disposed(by: cell.disposeBag)
@@ -274,6 +287,7 @@ extension FollowViewController {
         ) as! OtherFollowViewCell
         cell.selectionStyle = .none
         cell.setModel(model)
+        cell.updateButton(model.isFollowing)
         
         cell.profilBackgroundButton.rx.tap
             .subscribe(with: self) { object, _ in
@@ -298,7 +312,6 @@ extension FollowViewController {
         
         cell.followButton.rx.throttleTap(.seconds(1))
             .subscribe(with: self) { object, _ in
-                cell.updateButton(!model.isFollowing)
                 reactor.action.onNext(model.isFollowing ? .cancel(model.id) : .request(model.id))
             }
             .disposed(by: cell.disposeBag)

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
@@ -204,17 +204,13 @@ extension FollowViewController {
                 
                 if model.isRequester {
                     
-                    let mainTabBarController = MainTabBarController()
-                    mainTabBarController.reactor = reactor.reactorForMainTabBar()
-                    mainTabBarController.didSelectedIndex(3)
-                    let navigationController = UINavigationController(
-                        rootViewController: mainTabBarController
-                    )
-                    object.view.window?.rootViewController = navigationController
+                    let profileViewController = ProfileViewController()
+                    profileViewController.reactor = reactor.reactorForProfile(type: .myWithNavi, model.id)
+                    object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 } else {
                     
                     let profileViewController = ProfileViewController()
-                    profileViewController.reactor = reactor.reactorForProfile(memberId: model.id)
+                    profileViewController.reactor = reactor.reactorForProfile(type: .other, model.id)
                     object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 }
             }
@@ -252,17 +248,13 @@ extension FollowViewController {
                 
                 if model.isRequester {
                     
-                    let mainTabBarController = MainTabBarController()
-                    mainTabBarController.reactor = reactor.reactorForMainTabBar()
-                    mainTabBarController.didSelectedIndex(3)
-                    let navigationController = UINavigationController(
-                        rootViewController: mainTabBarController
-                    )
-                    object.view.window?.rootViewController = navigationController
+                    let profileViewController = ProfileViewController()
+                    profileViewController.reactor = reactor.reactorForProfile(type: .myWithNavi, model.id)
+                    object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 } else {
                     
                     let profileViewController = ProfileViewController()
-                    profileViewController.reactor = reactor.reactorForProfile(memberId: model.id)
+                    profileViewController.reactor = reactor.reactorForProfile(type: .other, model.id)
                     object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 }
             }
@@ -294,17 +286,13 @@ extension FollowViewController {
                 
                 if model.isRequester {
                     
-                    let mainTabBarController = MainTabBarController()
-                    mainTabBarController.reactor = reactor.reactorForMainTabBar()
-                    mainTabBarController.didSelectedIndex(3)
-                    let navigationController = UINavigationController(
-                        rootViewController: mainTabBarController
-                    )
-                    object.view.window?.rootViewController = navigationController
+                    let profileViewController = ProfileViewController()
+                    profileViewController.reactor = reactor.reactorForProfile(type: .myWithNavi, model.id)
+                    object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 } else {
                     
                     let profileViewController = ProfileViewController()
-                    profileViewController.reactor = reactor.reactorForProfile(memberId: model.id)
+                    profileViewController.reactor = reactor.reactorForProfile(type: .other, model.id)
                     object.navigationPush(profileViewController, animated: true, bottomBarHidden: true)
                 }
             }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewController.swift
@@ -296,6 +296,13 @@ extension FollowViewController {
             }
             .disposed(by: cell.disposeBag)
         
+        cell.followButton.rx.throttleTap(.seconds(1))
+            .subscribe(with: self) { object, _ in
+                cell.updateButton(!model.isFollowing)
+                reactor.action.onNext(model.isFollowing ? .cancel(model.id) : .request(model.id))
+            }
+            .disposed(by: cell.disposeBag)
+        
         return cell
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewReactor.swift
@@ -159,8 +159,8 @@ extension FollowViewReactor {
 
 extension FollowViewReactor {
     
-    func reactorForProfile(memberId: String) -> ProfileViewReactor {
-        ProfileViewReactor.init(type: .other, memberId: memberId)
+    func reactorForProfile(type: ProfileViewReactor.EntranceType, _ memberId: String) -> ProfileViewReactor {
+        ProfileViewReactor.init(type: type, memberId: memberId)
     }
     
     func reactorForMainTabBar() -> MainTabBarReactor {

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Follow/FollowViewReactor.swift
@@ -164,6 +164,6 @@ extension FollowViewReactor {
     }
     
     func reactorForMainTabBar() -> MainTabBarReactor {
-        MainTabBarReactor.init(willNavigate: .none)
+        MainTabBarReactor.init(pushInfo: nil)
     }
 }

--- a/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewController.swift
@@ -98,7 +98,7 @@ class ProfileViewController: BaseNavigationViewController, View {
     override func setupNaviBar() {
         super.setupNaviBar()
         
-        let isMine = self.reactor?.entranceType == .my
+        let isMine = self.reactor?.entranceType == .my || self.reactor?.entranceType == .myWithNavi
         
         let titleContainer = UIView()
         titleContainer.addSubview(self.titleView)
@@ -113,7 +113,7 @@ class ProfileViewController: BaseNavigationViewController, View {
             $0.bottom.leading.trailing.equalToSuperview()
         }
         
-        self.navigationBar.hidesBackButton = isMine
+        self.navigationBar.hidesBackButton = self.reactor?.entranceType == .my
         self.navigationBar.titleView = titleContainer
         if isMine {
             self.navigationBar.setRightButtons([self.rightSettingButton])
@@ -262,7 +262,7 @@ extension ProfileViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let entranceType = self.reactor?.entranceType ?? .my
         switch entranceType {
-        case .my:
+        case .my, .myWithNavi:
             let myCell: MyProfileViewCell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: MyProfileViewCell.cellIdentifier,
                 for: indexPath
@@ -392,7 +392,7 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
         let width: CGFloat = UIScreen.main.bounds.width
         // 내 프로필 일 때, 프로필 - 컨텐츠 + 컨텐츠 - 버튼 + 버튼 - 하단
         // 상대 프로필 일 때, 프로필 - 버튼 + 버튼 - 하단
-        let isMine = self.reactor?.entranceType == .my
+        let isMine = self.reactor?.entranceType == .my || self.reactor?.entranceType == .myWithNavi
         let spacing: CGFloat = isMine ? (16 + 18 + 30) : (22 + 22)
         // 내 프로필 일 떄, 프로필 + 간격 + 컨텐츠 + 버튼
         // 상대 프로필 일 때, 프로필 + 간격 + 버튼
@@ -408,7 +408,7 @@ extension ProfileViewController: UICollectionViewDelegateFlowLayout {
         let width: CGFloat = UIScreen.main.bounds.width
         // 내 프로필 일 때, 프로필 - 컨텐츠 + 컨텐츠 - 버튼 + 버튼 - 하단
         // 상대 프로필 일 때, 프로필 - 버튼 + 버튼 - 하단
-        let isMine = self.reactor?.entranceType == .my
+        let isMine = self.reactor?.entranceType == .my || self.reactor?.entranceType == .myWithNavi
         let spacing: CGFloat = isMine ? (16 + 18 + 30) : (22 + 22)
         // 내 프로필 일 떄, 프로필 + 간격 + 컨텐츠 + 버튼
         // 상대 프로필 일 때, 프로필 + 간격 + 버튼

--- a/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/ProfileViewReactor.swift
@@ -14,6 +14,7 @@ class ProfileViewReactor: Reactor {
     
     enum EntranceType {
         case my
+        case myWithNavi
         case other
     }
     
@@ -144,7 +145,7 @@ extension ProfileViewReactor {
         
         var request: ProfileRequest {
             switch self.entranceType {
-            case .my:
+            case .my, .myWithNavi:
                 return .myProfile
             case .other:
                 return .otherProfile(memberId: self.memberId ?? "")
@@ -166,7 +167,7 @@ extension ProfileViewReactor {
         
         var request: ProfileRequest {
             switch self.entranceType {
-            case .my:
+            case .my, .myWithNavi:
                 return .myCards(lastId: lastId)
             case .other:
                 return .otherCards(memberId: self.memberId ?? "", lastId: lastId)

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/CommentHistroyViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/CommentHistory/CommentHistroyViewController.swift
@@ -26,7 +26,6 @@ class CommentHistroyViewController: BaseNavigationViewController, View {
         $0.minimumLineSpacing = .zero
         $0.minimumInteritemSpacing = .zero
         $0.sectionInset = .zero
-        $0.estimatedItemSize = .zero
     }
     private lazy var collectionView = UICollectionView(
         frame: .zero,

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/MemberTransfer/Issue/IssueMemberTransferViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/MemberTransfer/Issue/IssueMemberTransferViewController.swift
@@ -165,7 +165,7 @@ class IssueMemberTransferViewController: BaseNavigationViewController, View {
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
-        self.updateTransferCodeButton.rx.throttleTap(.seconds(3))
+        self.updateTransferCodeButton.rx.throttleTap(.seconds(1))
             .map { _ in Reactor.Action.updateTransferCode }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewController.swift
@@ -39,9 +39,9 @@ class SettingsViewController: BaseNavigationViewController, View {
         static let unBlockDate: String = "차단 해제 날짜 : "
         
         static let adminMailStrUrl: String = "sooum1004@gmail.com"
+        static let identificationInfo: String = "식별 정보: "
         static let inquiryMailTitle: String = "[문의하기]"
         static let inquiryMailGuideMessage: String = """
-            식별 정보: [RefreshToken]
             \n
             문의 내용: 식별 정보 삭제에 주의하여 주시고, 이곳에 자유롭게 문의하실 내용을 적어주세요.
             단, 본 양식에 비방, 욕설, 허위 사실 유포 등의 부적절한 내용이 포함될 경우,
@@ -50,7 +50,6 @@ class SettingsViewController: BaseNavigationViewController, View {
         
         static let suggestMailTitle: String = "[제안하기]"
         static let suggestMailGuideMessage: String = """
-            식별 정보: [RefreshToken]
             \n
             제안 내용: 식별 정보 삭제에 주의하여 주시고, 이곳에 숨 개발팀에 제안할 내용을  자유롭게 작성해 주세요.
             단, 본 양식에 비방, 욕설, 허위 사실 유포 등의 부적절한 내용이 포함될 경우,
@@ -236,7 +235,12 @@ class SettingsViewController: BaseNavigationViewController, View {
         self.inquiryCellView.rx.didSelect
             .subscribe(with: self) { object, _ in
                 let subject = Text.inquiryMailTitle.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                let body = Text.inquiryMailGuideMessage.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                let guideMessage = """
+                    \(Text.identificationInfo)
+                    \(reactor.authManager.authInfo.token.refreshToken)\n
+                    \(Text.inquiryMailGuideMessage)
+                """
+                let body = guideMessage.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
                 let mailToString = "mailto:\(Text.adminMailStrUrl)?subject=\(subject)&body=\(body)"
                 
                 if let mailtoUrl = URL(string: mailToString),
@@ -250,7 +254,12 @@ class SettingsViewController: BaseNavigationViewController, View {
         self.suggestionCellView.rx.didSelect
             .subscribe(with: self) { object, _ in
                 let subject = Text.suggestMailTitle.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-                let body = Text.suggestMailGuideMessage.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                let guideMessage = """
+                    \(Text.identificationInfo)
+                    \(reactor.authManager.authInfo.token.refreshToken)\n
+                    \(Text.suggestMailGuideMessage)
+                """
+                let body = guideMessage.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
                 let mailToString = "mailto:\(Text.adminMailStrUrl)?subject=\(subject)&body=\(body)"
                 
                 if let mailtoUrl = URL(string: mailToString),

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewController.swift
@@ -175,14 +175,8 @@ class SettingsViewController: BaseNavigationViewController, View {
             .disposed(by: self.disposeBag)
         
         self.notificationSettingCellView.rx.didSelect
-            .subscribe(onNext: {
-                let application: UIApplication = .shared
-                let openSettingsURLString: String = UIApplication.openSettingsURLString
-                if let settingsURL = URL(string: openSettingsURLString),
-                    application.canOpenURL(settingsURL) {
-                        application.open(settingsURL)
-                }
-            })
+            .map { _ in Reactor.Action.updateNotificationStatus(!self.notificationSettingCellView.toggleSwitch.isOn) }
+            .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
         self.commentHistoryCellView.rx.didSelect

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewController.swift
@@ -175,7 +175,8 @@ class SettingsViewController: BaseNavigationViewController, View {
             .disposed(by: self.disposeBag)
         
         self.notificationSettingCellView.rx.didSelect
-            .map { _ in Reactor.Action.updateNotificationStatus(!self.notificationSettingCellView.toggleSwitch.isOn) }
+            .withUnretained(self)
+            .map { object, _ in Reactor.Action.updateNotificationStatus(!object.notificationSettingCellView.toggleSwitch.isOn) }
             .bind(to: reactor.action)
             .disposed(by: self.disposeBag)
         
@@ -220,14 +221,14 @@ class SettingsViewController: BaseNavigationViewController, View {
         
         self.announcementCellView.rx.didSelect
             .subscribe(with: self) { object, _ in
-                let announcementViewControler = AnnouncementViewControler()
-                announcementViewControler.reactor = reactor.reactorForAnnouncement()
-                object.navigationPush(announcementViewControler, animated: true, bottomBarHidden: true)
+                let announcementViewController = AnnouncementViewController()
+                announcementViewController.reactor = reactor.reactorForAnnouncement()
+                object.navigationPush(announcementViewController, animated: true, bottomBarHidden: true)
             }
             .disposed(by: self.disposeBag)
         
         self.inquiryCellView.rx.didSelect
-            .subscribe(with: self) { object, _ in
+            .subscribe(onNext: { _ in
                 let subject = Text.inquiryMailTitle.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
                 let guideMessage = """
                     \(Text.identificationInfo)
@@ -242,11 +243,11 @@ class SettingsViewController: BaseNavigationViewController, View {
                     
                     UIApplication.shared.open(mailtoUrl, options: [:], completionHandler: nil)
                 }
-            }
+            })
             .disposed(by: self.disposeBag)
         
         self.suggestionCellView.rx.didSelect
-            .subscribe(with: self) { object, _ in
+            .subscribe(onNext: { _ in
                 let subject = Text.suggestMailTitle.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
                 let guideMessage = """
                     \(Text.identificationInfo)
@@ -261,7 +262,7 @@ class SettingsViewController: BaseNavigationViewController, View {
                     
                     UIApplication.shared.open(mailtoUrl, options: [:], completionHandler: nil)
                 }
-            }
+            })
             .disposed(by: self.disposeBag)
         
         // State

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewReactor.swift
@@ -31,6 +31,7 @@ class SettingsViewReactor: Reactor {
     
     private let networkManager = NetworkManager.shared
     private let pushManager = PushManager.shared
+    let authManager = AuthManager.shared
     
     private let disposeBag = DisposeBag()
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/SettingsViewReactor.swift
@@ -7,6 +7,8 @@
 
 import ReactorKit
 
+import Alamofire
+
 
 class SettingsViewReactor: Reactor {
     
@@ -43,7 +45,8 @@ class SettingsViewReactor: Reactor {
             isProcessing: false
         )
         
-        self.subscribe()
+        // 서버 api를 통해서만 알림 허용 유무 변경
+        // self.subscribe()
     }
     
     private func subscribe() {
@@ -65,10 +68,25 @@ class SettingsViewReactor: Reactor {
                         return .just(.updateBanEndAt(response.banEndAt))
                     }
                     .catch(self.catchClosure),
+                self.networkManager.request(
+                    NotificationAllowResponse.self,
+                    request: SettingsRequest.notificationAllow(isAllowNotify: nil)
+                )
+                .flatMapLatest { response -> Observable<Mutation> in
+                    return .just(.updateNotificationStatus(response.isAllowNotify))
+                }
+                .catch(self.catchClosure),
                 .just(.updateIsProcessing(false))
             ])
         case let .updateNotificationStatus(state):
-            return .just(.updateNotificationStatus(state))
+            return self.networkManager.request(
+                Empty.self,
+                request: SettingsRequest.notificationAllow(isAllowNotify: state)
+            )
+            .flatMapLatest { _ -> Observable<Mutation> in
+                return .just(.updateNotificationStatus(state))
+            }
+            .catchAndReturn(.updateNotificationStatus(!state))
         }
     }
     

--- a/SOOUM/SOOUM/Presentations/Main/Profile/Settings/Views/SettingTextCellView.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Profile/Settings/Views/SettingTextCellView.swift
@@ -31,6 +31,8 @@ class SettingTextCellView: UIView {
         $0.isOn = false
         $0.onTintColor = .som.p300
         $0.thumbTintColor = .som.white
+        
+        $0.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
     }
     
     let backgroundButton = UIButton()
@@ -57,12 +59,6 @@ class SettingTextCellView: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        
-        self.toggleSwitch.transform = CGAffineTransform(scaleX: 0.8, y: 0.8)
     }
     
     private func setupConstraints() {

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/UploadCard/UpoadCardBottomSheet/UploadCardBottomSheetViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/UploadCard/UpoadCardBottomSheet/UploadCardBottomSheetViewController.swift
@@ -369,7 +369,7 @@ extension UploadCardBottomSheetViewController {
         config.library.minNumberOfItems = 1
         config.library.numberOfItemsInRow = 4
         config.library.spacingBetweenItems = 1.0
-        config.showsCrop = .rectangle(ratio: 10 / 9)
+        config.showsCrop = .rectangle(ratio: 1.0)
         config.showsPhotoFilters = false
         config.library.skipSelectionsGallery = false
         config.library.preselectedItems = nil

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/Views/PungTimeView.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/Views/PungTimeView.swift
@@ -1,0 +1,77 @@
+//
+//  PungTimeView.swift
+//  SOOUM
+//
+//  Created by 오현식 on 12/30/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+
+class PungTimeView: UIView {
+    
+    enum Text {
+        static let pungTimeGuideMessage: String = "이후에 카드가 삭제될 예정이에요"
+    }
+    
+    private let backgroundView = UIView().then {
+        $0.backgroundColor = .som.p300
+        $0.layer.cornerRadius = 12
+        $0.clipsToBounds = true
+    }
+    
+    private let pungTimeLabel = UILabel().then {
+        $0.textColor = .som.white
+        $0.typography = .som.body2WithBold
+    }
+    
+    private let pungTimeGuideLabel = UILabel().then {
+        $0.text = Text.pungTimeGuideMessage
+        $0.textColor = .som.gray700
+        $0.typography = .som.body2WithBold
+    }
+    
+    var text: String? {
+        set {
+            self.pungTimeLabel.text = newValue
+        }
+        get {
+            return self.pungTimeLabel.text
+        }
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.setupConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupConstraints() {
+        
+        self.addSubview(self.backgroundView)
+        self.backgroundView.snp.makeConstraints {
+            $0.top.bottom.leading.equalToSuperview()
+        }
+        
+        self.backgroundView.addSubview(self.pungTimeLabel)
+        self.pungTimeLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(10)
+            $0.trailing.equalToSuperview().offset(-10)
+        }
+        
+        self.addSubview(self.pungTimeGuideLabel)
+        self.pungTimeGuideLabel.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(self.backgroundView.snp.trailing).offset(3)
+            $0.trailing.equalToSuperview()
+        }
+    }
+}

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/Views/WriteCardView.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/Views/WriteCardView.swift
@@ -27,6 +27,10 @@ class WriteCardView: UIView {
         $0.placeholder = Text.wirteTagPlacholder
     }
     
+    let pungTimeView = PungTimeView().then {
+        $0.isHidden = true
+    }
+    
     let writtenTags = SOMTags(configure: .horizontalWithRemove).then {
         $0.tag = 0
     }
@@ -70,6 +74,13 @@ class WriteCardView: UIView {
             $0.top.equalTo(self.writtenTags.snp.bottom)
             $0.leading.equalToSuperview().offset(20)
             $0.trailing.equalToSuperview().offset(-20)
+        }
+        
+        self.addSubview(self.pungTimeView)
+        self.pungTimeView.snp.makeConstraints {
+            $0.top.equalTo(self.writtenTags.snp.bottom).offset(18)
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(25)
         }
         
         self.addSubview(self.relatedTagsBackgroundView)

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewController.swift
@@ -298,7 +298,7 @@ class WriteCardViewController: BaseNavigationViewController, View {
                 object.writeCardView.writeTagTextField.isHidden = isTimeLimit
                 object.writeCardView.writtenTagsHeightConstraint?.deactivate()
                 object.writeCardView.writtenTags.snp.makeConstraints {
-                    let height = self.writtenTagModels.isEmpty ? 12 : 58
+                    let height = object.writtenTagModels.isEmpty ? 12 : 58
                     let constraint = isTimeLimit ? $0.height.equalTo(0).constraint : $0.height.equalTo(height).constraint
                     object.writeCardView.writtenTagsHeightConstraint = constraint
                 }

--- a/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/WriteCard/WriteCardViewReactor.swift
@@ -56,11 +56,14 @@ class WriteCardViewReactor: Reactor {
     private let locationManager = LocationManager.shared
     
     let requestType: RequestType
-    private let cardIdForComment: String?
     
-    init(type requestType: RequestType, _ cardIdForComment: String? = nil) {
+    private let parentCardId: String?
+    let parentPungTime: Date?
+    
+    init(type requestType: RequestType, parentCardId: String? = nil, parentPungTime: Date? = nil) {
         self.requestType = requestType
-        self.cardIdForComment = cardIdForComment
+        self.parentCardId = parentCardId
+        self.parentPungTime = parentPungTime
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -105,7 +108,7 @@ class WriteCardViewReactor: Reactor {
             let trimedContent = content.trimmingCharacters(in: .whitespacesAndNewlines)
             
             let request: CardRequest = .writeComment(
-                id: self.cardIdForComment ?? "",
+                id: self.parentCardId ?? "",
                 isDistanceShared: !isDistanceShared,
                 latitude: coordinate.latitude,
                 longitude: coordinate.longitude,

--- a/SOOUM/SOOUM/Presentations/Onboarding/ProfileImageSetting/ProfileImageSettingViewController.swift
+++ b/SOOUM/SOOUM/Presentations/Onboarding/ProfileImageSetting/ProfileImageSettingViewController.swift
@@ -67,7 +67,7 @@ class ProfileImageSettingViewController: BaseNavigationViewController, View {
             .distinctUntilChanged()
             .subscribe(with: self) { object, shouldNavigate in
                 let viewController = MainTabBarController()
-                viewController.reactor = MainTabBarReactor(willNavigate: .none)
+                viewController.reactor = MainTabBarReactor(pushInfo: nil)
                 let navigationController = UINavigationController(
                     rootViewController: viewController
                 )

--- a/SOOUM/SOOUM/Resources/Alamofire/Develop/AuthRequest.swift
+++ b/SOOUM/SOOUM/Resources/Alamofire/Develop/AuthRequest.swift
@@ -115,6 +115,10 @@ enum AuthRequest: BaseRequest {
             
             // 재인증 API는 access와 refresh 둘 다 사용
             switch self.authorizationType {
+            case .access:
+                let authPayloadForAccess = AuthManager.shared.authPayloadByAccess()
+                let authKeyForAccess = authPayloadForAccess.keys.first! as String
+                request.setValue(authPayloadForAccess[authKeyForAccess], forHTTPHeaderField: authKeyForAccess)
             case .refresh:
                 let authPayloadForRefresh = AuthManager.shared.authPayloadByRefresh()
                 let authKeyForRefresh = authPayloadForRefresh.keys.first! as String

--- a/SOOUM/SOOUM/Resources/Alamofire/Develop/NotificationRequest.swift
+++ b/SOOUM/SOOUM/Resources/Alamofire/Develop/NotificationRequest.swift
@@ -16,7 +16,7 @@ enum NotificationRequest: BaseRequest {
     case totalRead(lastId: String?)
     case commentWithoutRead(lastId: String?)
     case commentRead(lastId: String?)
-    case likeWithoutRead(id: String?)
+    case likeWithoutRead(lastId: String?)
     case likeRead(lastId: String?)
     
     case requestRead(notificationId: String)

--- a/SOOUM/SOOUM/Resources/Alamofire/Develop/SettingsRequest.swift
+++ b/SOOUM/SOOUM/Resources/Alamofire/Develop/SettingsRequest.swift
@@ -13,6 +13,7 @@ import Alamofire
 enum SettingsRequest: BaseRequest {
 
     case activate
+    case notificationAllow(isAllowNotify: Bool?)
     case commentHistory(lastId: String?)
     case transferCode(isUpdate: Bool)
     case transferMember(transferId: String, encryptedDeviceId: String)
@@ -24,6 +25,8 @@ enum SettingsRequest: BaseRequest {
         switch self {
         case .activate:
             return "/settings/status"
+        case .notificationAllow:
+            return "/members/notify"
         case .commentHistory:
             return "/members/comment-cards"
         case .resign:
@@ -37,6 +40,8 @@ enum SettingsRequest: BaseRequest {
 
     var method: HTTPMethod {
         switch self {
+        case let .notificationAllow(isAllowNotify):
+            return isAllowNotify == nil ? .get : .patch
         case let .transferCode(isUpdate):
             return isUpdate ? .patch : .get
         case .transferMember:
@@ -50,6 +55,12 @@ enum SettingsRequest: BaseRequest {
 
     var parameters: Parameters {
         switch self {
+        case let .notificationAllow(isAllowNotify):
+            if let isAllowNotify = isAllowNotify {
+                return ["isAllowNotify": isAllowNotify]
+            } else {
+                return [:]
+            }
         case let .transferMember(transferId, encryptedDeviceId):
             return ["transferId": transferId, "encryptedDeviceId": encryptedDeviceId]
         case let .commentHistory(lastId):
@@ -66,6 +77,8 @@ enum SettingsRequest: BaseRequest {
 
     var encoding: ParameterEncoding {
         switch self {
+        case let .notificationAllow(isAllowNotify):
+            return isAllowNotify == nil ? URLEncoding.default : JSONEncoding.default
         case .transferMember, .resign:
             return JSONEncoding.default
         default:


### PR DESCRIPTION
<!--
  제목은 `[지라 작업번호] 작업 내용 요약`으로 작성해주세요.
-->

## 설명
### 작업 내용
<!-- 
  - PR 본문을 입력해주세요.
-->
메인 홈
 - 피드 카드 페이징 처리 제거
 - SOMCard 본문 길어지면 스크롤 처리 (아직 스크롤은 안됨...)

설정
 - 문의하기, 제안하기 메일 폼에 실제 refreshToken 추가
 - 알림 허용 시 앱의 알림 설정은 수정하지 않고 api로 조절
 - 공지사항 화면 로딩 뷰 표시 로직 수정

프로필
 - 팔로우 화면에서 팔로잉가능하게 수정 (+ 팔로우 버튼 동기화)

글추가
 - 크롭된 사진 비율 1.0으로 고정
 - 답글 추가에서 전글이 시간제한 카드이면 펑 시간 및 가이드 라벨 표시

알림
 - 메인 홈 화면에서 알림이 존재 시 뷰 추가
 - 푸시 알림을 탭해도 읽음 처리 가능하게 수정
 - 상세보기 전환 시 삭제된 카드면 알림 화면으로 전환
 - 완전 종료 되었을 때 알림 탭하면 런치 스크린부터 전환, 그 외의 경우 메인 탭바 화면

## 참고 링크
<!--
  (Optional) 검토시 참고할 만한 자료를 공유해주세요.
  - 기획 문서, 디자인 문서, slack 메시지의 링크를 추가합니다.
  - 개발시 참고했던 기술 문서, article 등을 추가합니다.
-->
[APP 버전별 피드백 (105010)](https://www.notion.so/APP-763045177ba34a9a968b3b502efa6aac?pvs=4)