### PR TITLE
[수정] 서버 버전이 클라이언트 버전 보다 낮을 경우, 계정 이관 숨기기 적용

### DIFF
--- a/SOOUM/SOOUM/Managers/NetworkManager/Models/Version.swift
+++ b/SOOUM/SOOUM/Managers/NetworkManager/Models/Version.swift
@@ -27,4 +27,8 @@ extension Version {
     var mustUpdate: Bool {
         Self.thisAppVersion.currentVerion.compare(self.currentVerion, options: .numeric).rawValue < 0
     }
+  
+    var shouldHideTransfer: Bool {
+        Self.thisAppVersion.currentVerion.compare(self.currentVerion, options: .numeric).rawValue > 0
+    }
 }

--- a/SOOUM/SOOUM/Presentations/Intro/Launch/LaunchScreenViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Intro/Launch/LaunchScreenViewReactor.swift
@@ -60,10 +60,7 @@ class LaunchScreenViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .launch:
-            return .concat([
-                self.fetchAppFlag(),
-                self.check()
-            ])
+            return self.check()
         }
     }
     
@@ -99,24 +96,12 @@ extension LaunchScreenViewReactor {
             .withUnretained(self)
             .flatMapLatest { object, currentVersion -> Observable<Mutation> in
                 let model = Version(currentVerion: currentVersion)
+                UserDefaults.standard.set(model.shouldHideTransfer, forKey: "AppFlag")
                 if model.mustUpdate {
                     return .just(.check(true))
                 } else {
                     return self.provider.authManager.hasToken ? .just(.updateIsRegistered(true)) : object.login()
                 }
-            }
-    }
-    
-    private func fetchAppFlag() -> Observable<Mutation> {
-        let request: ConfigureRequest = .appFlag
-        return provider.networkManager.request(Bool.self, request: request)
-            .map { flag in
-                UserDefaults.standard.set(flag, forKey: "AppFlag")
-                return Mutation.appFlag(flag)
-            }
-            .catch { _ in
-                UserDefaults.standard.set(true, forKey: "AppFlag")
-                return .just(Mutation.appFlag(false))
             }
     }
 }


### PR DESCRIPTION
<!--
  제목은 `[지라 작업번호] 작업 내용 요약`으로 작성해주세요.
-->

## 설명
### 작업 배경
기존 앱 심사 플래그 방식은 심사 중에 실제 유저가 계정이관을 사용하지 못하는 이슈가 있었음
따라서 심사 중임을 확인하는 다른 방법을 적용함
<!--
  - PR을 올리게 된 배경을 입력해주세요.
-->
### 작업 내용
<!-- 
  - PR 본문을 입력해주세요.
-->
런치 스크린에서 클라이언트 버전이 서버 버전보다 높을때 심사 중으로 판단하는 로직을 추가

### 스크린샷
<!--
  (Optional) UI가 변경되었다면 수정 전/후 이미지를 추가해주세요.
  너비 조절이 필요한 경우 아래 태그를 사용하세요.
  <img alt="{대체 텍스트}" src="{이미지 주소}" width="{이미지 너비}">
-->
## 기타
<!--
  (Optional)
  - 리뷰 시에 유심히 봐주었으면 하는 부분을 알려주세요.
  - merge 전 필요한 작업이 있다면 알려주세요.
  - 기타 등등 자유롭게 작성해주세요.
-->
<!--
  `test/~/~` 브랜치를 체크아웃하여 `../*.swift` 파일의 100~120번 줄에서 예시를 확인하실 수 있습니다.
-->
**[테스트 가이드]**
-

## 참고 링크
<!--
  (Optional) 검토시 참고할 만한 자료를 공유해주세요.
  - 기획 문서, 디자인 문서, slack 메시지의 링크를 추가합니다.
  - 개발시 참고했던 기술 문서, article 등을 추가합니다.
-->