### PR TITLE
계정 이관 성공 푸시 알림 받았을 때, 온보딩 화면으로 전환

### DIFF
--- a/SOOUM/SOOUM/App/AppDelegate.swift
+++ b/SOOUM/SOOUM/App/AppDelegate.swift
@@ -40,6 +40,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Set log
         self.setupCocoaLumberjack()
         
+        // Initalize token
+        self.initializeTokenWhenFirstLaunch()
+        
         // Set managers
         self.provider.initialize()
         
@@ -48,9 +51,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Messaging.messaging().delegate = self
         // 앱 실행 시 사용자에게 알림 허용 권한을 받음
         UNUserNotificationCenter.current().delegate = self
-        
-        // 앱 첫 실행 시 할 일
-        self.todoFirstLaunch()
         
         return true
     }
@@ -159,8 +159,7 @@ extension AppDelegate {
         DDLog.add(fileLogger)
     }
     
-    private func todoFirstLaunch() {
-        
+    private func initializeTokenWhenFirstLaunch() {
         guard UserDefaults.isFirstLaunch else { return }
         
         // 앱 첫 실행 시 token 정보 제거

--- a/SOOUM/SOOUM/App/AppDelegate.swift
+++ b/SOOUM/SOOUM/App/AppDelegate.swift
@@ -155,7 +155,7 @@ extension AppDelegate {
 
         let fileLogger: DDFileLogger = DDFileLogger() // File Logger
         fileLogger.rollingFrequency = 60 * 60 * 24 // 24 hours
-        fileLogger.logFileManager.maximumNumberOfLogFiles = 7
+        fileLogger.logFileManager.maximumNumberOfLogFiles = 1 // Always recent
         DDLog.add(fileLogger)
     }
     

--- a/SOOUM/SOOUM/App/AppDelegate.swift
+++ b/SOOUM/SOOUM/App/AppDelegate.swift
@@ -77,36 +77,47 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     
-    // Foreground(앱 켜진 상태)에서도 알림 오는 설정
+    /// Foreground(앱 켜진 상태)에서도 알림 오는 설정
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
+        // 계정 이관 성공 시 (런치 화면 > 온보딩 화면)으로 전환
+        let userInfo = notification.request.content.userInfo
+        self.setupOnboardingWhenTransferSuccessed(userInfo)
         
         let options: UNNotificationPresentationOptions = [.sound, .list, .banner]
         completionHandler(options)
     }
     
-    /// 사용자가 push notification에 대한 응답을 했을 때 실행할 코드 작성
+    /// 사용자가 push notification에 대한 응답을 했을 때 실행
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let userInfo: [AnyHashable: Any] = response.notification.request.content.userInfo
-
-        if let messageID: String = userInfo["gcm.message_id"] as? String {
-            Log.info("Message ID: \(messageID)")
-        }
-        
         if let infoDic = userInfo as? [String: Any] {
             
             let info = NotificationInfo(infoDic)
-            self.provider.pushManager.setupRootViewController(info, terminated: false)
+            // 계정 이관 성공 알림일 경우 (런치 화면 > 온보딩 화면), 아닐 경우 메인 홈 탭바 화면 전환
+            self.provider.pushManager.setupRootViewController(info, terminated: info.isTransfered)
         }
 
         completionHandler()
+    }
+    
+    // 백그라운드 혹은 완전 종료일 때
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        // 계정 이관 성공 시 (런치 화면 > 온보딩 화면)으로 전환
+        self.setupOnboardingWhenTransferSuccessed(userInfo)
+        
+        completionHandler(.newData)
     }
 }
 
@@ -165,5 +176,15 @@ extension AppDelegate {
         // 앱 첫 실행 시 token 정보 제거
         AuthKeyChain.shared.delete(.accessToken)
         AuthKeyChain.shared.delete(.refreshToken)
+    }
+    
+    private func setupOnboardingWhenTransferSuccessed(_ userInfo: [AnyHashable: Any]?) {
+        guard let infoDic = userInfo as? [String: Any] else { return }
+        
+        let info = NotificationInfo(infoDic)
+        if info.isTransfered {
+            
+            self.provider.pushManager.setupRootViewController(info, terminated: true)
+        }
     }
 }

--- a/SOOUM/SOOUM/App/SceneDelegate.swift
+++ b/SOOUM/SOOUM/App/SceneDelegate.swift
@@ -45,8 +45,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
     }
 
-    func sceneDidDisconnect(_ scene: UIScene) { }
-
     func sceneDidBecomeActive(_ scene: UIScene) { }
 
     func sceneWillResignActive(_ scene: UIScene) { }
@@ -55,6 +53,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         // 앱이 백그라운드 상태로 전환 되면, 모든 캐시 삭제
+        Kingfisher.ImageCache.default.clearCache()
+    }
+    
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // 앱이 완전히 종료되었을 때, 모든 캐시 삭제
         Kingfisher.ImageCache.default.clearCache()
     }
 }

--- a/SOOUM/SOOUM/Managers/PushManager/Models/NotificationInfo.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/Models/NotificationInfo.swift
@@ -14,6 +14,10 @@ class NotificationInfo {
     let notificationId: String?
     let targetCardId: String?
     
+    var isTransfered: Bool {
+        return self.notificationType == .transfer
+    }
+    
     init(_ info: [String: Any]) {
         let notificationType = info["notificationType"] as? String ?? ""
         self.notificationType = CommentHistoryInNoti.NotificationType(rawValue: notificationType)

--- a/SOOUM/SOOUM/Models/Notification/CommentHistoryInNotiResponse.swift
+++ b/SOOUM/SOOUM/Models/Notification/CommentHistoryInNotiResponse.swift
@@ -55,6 +55,7 @@ struct CommentHistoryInNoti: Equatable, Codable {
         case commentWrite = "COMMENT_WRITE"
         case blocked = "BLOCKED"
         case delete = "DELETED"
+        case transfer = "TRANSFER_SUCCESS"
         
         var description: String {
             switch self {

--- a/SOOUM/SOOUM/Presentations/Intro/Launch/LaunchScreenViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Intro/Launch/LaunchScreenViewReactor.swift
@@ -60,7 +60,14 @@ class LaunchScreenViewReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .launch:
-            return self.check()
+            // 계정 이관에 성공했을 때, 온보딩 화면으로 전환
+            let isTransfered = self.pushInfo?.isTransfered ?? false
+            if isTransfered {
+                self.provider.authManager.initializeAuthInfo()
+                return .just(.updateIsRegistered(false))
+            } else {
+                return self.check()
+            }
         }
     }
     
@@ -96,7 +103,9 @@ extension LaunchScreenViewReactor {
             .withUnretained(self)
             .flatMapLatest { object, currentVersion -> Observable<Mutation> in
                 let model = Version(currentVerion: currentVersion)
+                
                 UserDefaults.standard.set(model.shouldHideTransfer, forKey: "AppFlag")
+                
                 if model.mustUpdate {
                     return .just(.check(true))
                 } else {


### PR DESCRIPTION
<!--
  제목은 `[지라 작업번호] 작업 내용 요약`으로 작성해주세요.
-->

## 설명
### 작업 배경
<!--
  - PR을 올리게 된 배경을 입력해주세요.
-->
 - 계정 이관 성공 시 기존 기기를 사용할 수 있던 문제 해결 (정책 상 같은 계정을 동시에 사용 X)
### 작업 내용
<!-- 
  - PR 본문을 입력해주세요.
-->
 - 계정 이관 성공 푸시 알림 받았을 때, 온보딩 화면으로 전환
 - 로그 파일 최대 1개로 갯수 제한