### PR TITLE
버전 검사 API 응답 시 기존 request 사용

### DIFF
--- a/SOOUM/SOOUM-DevTests/Managers/Network/MockNetworkManager.swift
+++ b/SOOUM/SOOUM-DevTests/Managers/Network/MockNetworkManager.swift
@@ -62,8 +62,6 @@ class MockNetworkManager: CompositeManager<NetworkManagerConfiguration>, Network
         }
     }
     
-    func checkClientVersion() -> Observable<String> { return Observable.just("1.0.0") }
-    
     func registerFCMToken(with tokenSet: PushTokenSet, _ function: String) { }
     
     func registerFCMToken(from function: String) { }

--- a/SOOUM/SOOUM/Managers/NetworkManager/NetworkManager.swift
+++ b/SOOUM/SOOUM/Managers/NetworkManager/NetworkManager.swift
@@ -20,8 +20,6 @@ protocol NetworkManagerDelegate: AnyObject {
         to url: URLConvertible
     ) -> Observable<Result<Void, Error>>
     
-    func checkClientVersion() -> Observable<String>
-    
     func registerFCMToken(with tokenSet: PushTokenSet, _ function: String)
     func registerFCMToken(from function: String)
 }
@@ -136,36 +134,6 @@ extension NetworkManager: NetworkManagerDelegate {
                             observer.onCompleted()
                         }
                     case .failure(let error):
-                        Log.error("Network or response format error: \(error)")
-                        observer.onError(error)
-                    }
-                }
-            
-            return Disposables.create {
-                task?.cancel()
-            }
-        }
-    }
-    
-    
-    // MARK: Check version
-    
-    func checkClientVersion() -> Observable<String> {
-        
-        return Observable.create { [weak self] observer -> Disposable in
-            
-            let task = self?.session.request(AuthRequest.updateCheck)
-                .validate(statusCode: 200..<500)
-                .responseString { response in
-                    switch response.result {
-                    case let .success(value):
-                        if let error = response.error {
-                            observer.onError(error)
-                        } else {
-                            observer.onNext(value)
-                            observer.onCompleted()
-                        }
-                    case let .failure(error):
                         Log.error("Network or response format error: \(error)")
                         observer.onError(error)
                     }

--- a/SOOUM/SOOUM/Presentations/Intro/Launch/LaunchScreenViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Intro/Launch/LaunchScreenViewReactor.swift
@@ -99,7 +99,7 @@ extension LaunchScreenViewReactor {
     
     private func check() -> Observable<Mutation> {
         
-        return self.provider.networkManager.checkClientVersion()
+        return self.provider.networkManager.request(String.self, request: AuthRequest.updateCheck)
             .withUnretained(self)
             .flatMapLatest { object, currentVersionStatus -> Observable<Mutation> in
                 let version = Version(status: currentVersionStatus)


### PR DESCRIPTION
<!--
  제목은 `[지라 작업번호] 작업 내용 요약`으로 작성해주세요.
-->

## 설명
### 작업 배경
<!--
  - PR을 올리게 된 배경을 입력해주세요.
-->
 - 기존 버전 검사 API는 responseString으로 응답을 받아 문자열에 이스케이프 문자열이 포함됨
### 작업 내용
<!-- 
  - PR 본문을 입력해주세요.
-->
 - 기존 request 함수를 그대로 사용해 서버에서 응답받은 문자열을 그대로 사용