### PR TITLE
[추가] NotificationViewReactor 알림 삭제 코드 추가

### DIFF
--- a/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
+++ b/SOOUM/SOOUM/Managers/PushManager/PushManager.swift
@@ -16,6 +16,7 @@ protocol PushManagerDelegate: AnyObject {
     var canReceiveNotifications: Bool { get }
     var notificationStatus: Bool { get }
     func switchNotification(isOn: Bool, completion: ((Error?) -> Void)?)
+    func deleteNotification(notificationId: String)
 }
 
 class PushManager: CompositeManager<PushManagerConfiguration> {
@@ -162,6 +163,21 @@ extension PushManager: PushManagerDelegate {
             }
         }
     }
+    
+    func deleteNotification(notificationId: String) {
+        UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+            let matchedIds = notifications
+                .filter {
+                    ($0.request.content.userInfo["notificationId"] as? String) == notificationId
+                }
+                .map { $0.request.identifier }
+            
+            if !matchedIds.isEmpty {
+                UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: matchedIds)
+            }
+        }
+    }
+    
 }
 
 extension PushManagerDelegate {

--- a/SOOUM/SOOUM/Presentations/Main/Home/Notification/Views/NotificationViewReactor.swift
+++ b/SOOUM/SOOUM/Presentations/Main/Home/Notification/Views/NotificationViewReactor.swift
@@ -111,6 +111,7 @@ class NotificationViewReactor: Reactor {
             ])
             
         case let .requestRead(selectedId):
+            self.provider.pushManager.deleteNotification(notificationId: selectedId)
             let request: NotificationRequest = .requestRead(notificationId: selectedId)
             return self.provider.networkManager.request(Empty.self, request: request)
                 .map { _ in .updateIsReadCompleted(true) }


### PR DESCRIPTION
<!--
  제목은 `[지라 작업번호] 작업 내용 요약`으로 작성해주세요.
-->

## 설명
### 작업 배경
앱 내에서 알림을 읽었을 때, 알림센터(iOS 시스템 푸시 알림)에서도 해당 알림을 자동으로 제거하는 UX 개선이 필요했음
<!--
  - PR을 올리게 된 배경을 입력해주세요.
-->
### 작업 내용
<!-- 
  - PR 본문을 입력해주세요.
-->
읽은 알림에 해당하는 notificationId를 기반으로
UNUserNotificationCenter에서 알림센터 알림 제거 처리 추가
### 스크린샷
<!--
  (Optional) UI가 변경되었다면 수정 전/후 이미지를 추가해주세요.
  너비 조절이 필요한 경우 아래 태그를 사용하세요.
  <img alt="{대체 텍스트}" src="{이미지 주소}" width="{이미지 너비}">
-->

## 기타
<!--
  (Optional)
  - 리뷰 시에 유심히 봐주었으면 하는 부분을 알려주세요.
  - merge 전 필요한 작업이 있다면 알려주세요.
  - 기타 등등 자유롭게 작성해주세요.
-->
<!--
  `test/~/~` 브랜치를 체크아웃하여 `../*.swift` 파일의 100~120번 줄에서 예시를 확인하실 수 있습니다.
-->
**[테스트 가이드]**
-

## 참고 링크
<!--
  (Optional) 검토시 참고할 만한 자료를 공유해주세요.
  - 기획 문서, 디자인 문서, slack 메시지의 링크를 추가합니다.
  - 개발시 참고했던 기술 문서, article 등을 추가합니다.
-->